### PR TITLE
Add users endpoint

### DIFF
--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -33,3 +33,14 @@ def me():
     user_id = get_jwt_identity()
     user = User.query.get(user_id)
     return jsonify(username=user.username, email=user.email)
+
+
+@bp.route('/users', methods=['GET'])
+@jwt_required()
+def get_users():
+    users = User.query.all()
+    user_list = [
+        {"id": u.id, "username": u.username, "email": u.email}
+        for u in users
+    ]
+    return jsonify(user_list), 200


### PR DESCRIPTION
## Summary
- add a new `/users` route to list all users

## Testing
- `python3 -m py_compile backend/app/routes/auth.py`


------
https://chatgpt.com/codex/tasks/task_e_684dd394d980832e93cd6ee28d1fa082