### PR TITLE
Add separate layout for auth pages

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,14 +1,24 @@
 <template>
-  <MainLayout>
+  <component :is="layout">
     <router-view />
-  </MainLayout>
+  </component>
 </template>
 
 <script>
+import { computed } from 'vue';
+import { useRoute } from 'vue-router';
 import MainLayout from './layouts/MainLayout.vue';
+import AuthLayout from './layouts/AuthLayout.vue';
 
 export default {
   name: 'App',
-  components: { MainLayout }
+  components: { MainLayout, AuthLayout },
+  setup() {
+    const route = useRoute();
+    const layout = computed(() =>
+      route.meta.layout === 'auth' ? AuthLayout : MainLayout
+    );
+    return { layout };
+  }
 };
 </script>

--- a/frontend/src/components/AppModal.vue
+++ b/frontend/src/components/AppModal.vue
@@ -1,0 +1,29 @@
+<template>
+  <v-dialog v-model="model" max-width="500">
+    <v-card>
+      <slot />
+    </v-card>
+  </v-dialog>
+</template>
+
+<script>
+export default {
+  name: 'AppModal',
+  props: {
+    modelValue: {
+      type: Boolean,
+      default: false
+    }
+  },
+  computed: {
+    model: {
+      get() {
+        return this.modelValue;
+      },
+      set(val) {
+        this.$emit('update:modelValue', val);
+      }
+    }
+  }
+};
+</script>

--- a/frontend/src/layouts/AuthLayout.vue
+++ b/frontend/src/layouts/AuthLayout.vue
@@ -1,0 +1,28 @@
+<template>
+  <v-app>
+    <AppHeader />
+    <v-main>
+      <slot />
+    </v-main>
+    <AppFooter />
+    <AppModal v-model="showModal">
+      <slot name="modal" />
+    </AppModal>
+  </v-app>
+</template>
+
+<script>
+import AppHeader from '../components/Header.vue';
+import AppFooter from '../components/Footer.vue';
+import AppModal from '../components/AppModal.vue';
+
+export default {
+  name: 'AuthLayout',
+  components: { AppHeader, AppFooter, AppModal },
+  data() {
+    return {
+      showModal: false
+    };
+  }
+};
+</script>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -4,8 +4,8 @@ import Register from '../views/Register.vue';
 import Home from '../views/Home.vue';
 
 const routes = [
-  { path: '/login', component: Login },
-  { path: '/register', component: Register },
+  { path: '/login', component: Login, meta: { layout: 'auth' } },
+  { path: '/register', component: Register, meta: { layout: 'auth' } },
   { path: '/', component: Home }
 ];
 

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -1,8 +1,7 @@
 <template>
-  <v-app>
-    <v-main class="fill-height">
-      <v-container fluid>
-        <v-row align="center" justify="center">
+  <div class="fill-height">
+    <v-container fluid>
+      <v-row align="center" justify="center">
           <v-col cols="12" sm="8" md="4">
             <v-card class="pa-6 rounded-lg elevation-8">
               <div class="logo-container">
@@ -62,8 +61,7 @@
           </v-col>
         </v-row>
       </v-container>
-    </v-main>
-  </v-app>
+    </div>
 </template>
 
 <script setup>

--- a/frontend/src/views/Register.vue
+++ b/frontend/src/views/Register.vue
@@ -1,8 +1,7 @@
 <template>
-  <v-app>
-    <v-main class="fill-height">
-      <v-container fluid>
-        <v-row align="center" justify="center">
+  <div class="fill-height">
+    <v-container fluid>
+      <v-row align="center" justify="center">
           <v-col cols="12" sm="8" md="4">
             <v-card class="pa-6 rounded-lg elevation-8">
               <div class="logo-container">
@@ -62,8 +61,7 @@
           </v-col>
         </v-row>
       </v-container>
-    </v-main>
-  </v-app>
+    </div>
 </template>
 
 <script setup>


### PR DESCRIPTION
## Summary
- add a simple `AppModal` component
- create `AuthLayout` without sidebar
- switch layouts dynamically in `App.vue`
- tag login and register routes to use `AuthLayout`
- remove v-app wrapper from login and register views

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68506a7aab8c832ebb78ba4b2ff3bd2a