### PR TITLE
Disable sidebar on login/register

### DIFF
--- a/frontend/src/components/Header.vue
+++ b/frontend/src/components/Header.vue
@@ -1,6 +1,6 @@
 <template>
   <v-app-bar color="primary" dark>
-    <v-app-bar-nav-icon @click="$emit('toggle-drawer')" />
+    <v-app-bar-nav-icon v-if="user" @click="$emit('toggle-drawer')" />
     <v-toolbar-title>Sistema de Gestão do Núcleo de Multas - SIGEM</v-toolbar-title>
     <v-spacer></v-spacer>
     <v-menu v-if="user" offset-y>

--- a/frontend/src/layouts/MainLayout.vue
+++ b/frontend/src/layouts/MainLayout.vue
@@ -1,6 +1,6 @@
 <template>
   <v-app>
-    <AppSidebar v-model="drawer" />
+    <AppSidebar v-if="user" v-model="drawer" />
     <AppHeader
       :user="user"
       @logout="logout"


### PR DESCRIPTION
## Summary
- hide sidebar until user is logged in
- remove drawer button from header for guests

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_6851a9d77534832eaa6132ff63f2987b