### PR TITLE
Update frontend API base URL

### DIFF
--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,7 +1,8 @@
 import axios from 'axios';
 
 const api = axios.create({
-  baseURL: 'http://localhost:8000'
+  // Base URL points to the Flask backend. Adjust the port if needed.
+  baseURL: 'http://localhost:5000/api'
 });
 
 export function registerUser(payload) {


### PR DESCRIPTION
## Summary
- point the Vue app's Axios base URL to the Flask backend on port 5000

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6851ac5fcb40832e936a7a083c5065aa