### PR TITLE
Implement token handling in Vuex and API

### DIFF
--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,7 +1,16 @@
 import axios from 'axios';
+import store from '../store';
 
 const api = axios.create({
   baseURL: 'http://localhost:8000'
+});
+
+api.interceptors.request.use(config => {
+  const token = store.state.token || localStorage.getItem('token');
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
 });
 
 export function registerUser(payload) {
@@ -10,6 +19,10 @@ export function registerUser(payload) {
 
 export function loginUser(payload) {
   return api.post('/auth/login', payload);
+}
+
+export function getCurrentUser() {
+  return api.get('/auth/me');
 }
 
 export default api;

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -2,14 +2,21 @@ import { createStore } from 'vuex';
 
 export default createStore({
   state: {
-    user: null
+    user: null,
+    token: localStorage.getItem('token') || null
   },
   mutations: {
     setUser(state, user) {
       state.user = user;
     },
+    setToken(state, token) {
+      state.token = token;
+      localStorage.setItem('token', token);
+    },
     logout(state) {
       state.user = null;
+      state.token = null;
+      localStorage.removeItem('token');
     }
   },
   actions: {},

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -66,7 +66,12 @@
 
 <script setup>
 import { ref } from 'vue'
-import { loginUser } from '../services/api'
+import { useStore } from 'vuex'
+import { useRouter } from 'vue-router'
+import { loginUser, getCurrentUser } from '../services/api'
+
+const store = useStore()
+const router = useRouter()
 
 const cpf = ref('')
 const senha = ref('')
@@ -85,7 +90,15 @@ const rules = {
 function login() {
   if (!formRef.value?.validate()) return
   loginUser({ username: cpf.value, password: senha.value })
-    .then(() => console.log('logado'))
+    .then(res => {
+      const token = res.data.access_token
+      store.commit('setToken', token)
+      return getCurrentUser()
+    })
+    .then(res => {
+      store.commit('setUser', res.data)
+      router.push('/')
+    })
     .catch(err => console.error(err))
 }
 </script>


### PR DESCRIPTION
## Summary
- store JWT token in Vuex and localStorage
- add request interceptor to set Authorization header
- update login flow to save token and fetch user data

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6851ac742b9c832eb0e6f0cfa950ed32