### PR TITLE
Switch to email login

### DIFF
--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -21,7 +21,7 @@ def register():
 @bp.route('/login', methods=['POST'])
 def login():
     data = request.get_json()
-    user = User.query.filter_by(username=data['username']).first()
+    user = User.query.filter_by(email=data['email']).first()
     if user and user.check_password(data['password']):
         access_token = create_access_token(identity=str(user.id))
         return jsonify(access_token=access_token)

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -18,12 +18,11 @@
 
             <v-form ref="formRef" v-model="formValid">
               <v-text-field
-                v-model="cpf"
-                label="CPF"
-                prepend-inner-icon="mdi-account"
-                maxlength="14"
+                v-model="email"
+                label="Email"
+                prepend-inner-icon="mdi-email"
                 outlined
-                :rules="[rules.required, rules.cpf]"
+                :rules="[rules.required, rules.email]"
                 class="mb-4"
               ></v-text-field>
 
@@ -70,7 +69,7 @@ import { useRouter } from 'vue-router'
 import { useStore } from 'vuex'
 import { loginUser } from '../services/api'
 
-const cpf = ref('')
+const email = ref('')
 const senha = ref('')
 const formRef = ref(null)
 const formValid = ref(false)
@@ -80,16 +79,13 @@ const store = useStore()
 
 const rules = {
   required: v => !!v || 'Campo obrigatório',
-  cpf: v => {
-    const digits = String(v || '').replace(/\D/g, '')
-    return digits.length === 11 || 'CPF inválido'
-  }
+  email: v => /.+@.+\..+/.test(String(v)) || 'E-mail inválido'
 }
 
 async function login() {
   if (!formRef.value?.validate()) return
   try {
-    const { data } = await loginUser({ username: cpf.value, password: senha.value })
+    const { data } = await loginUser({ email: email.value, password: senha.value })
     store.commit('setToken', data.access_token)
     await store.dispatch('fetchCurrentUser')
     router.push('/')

--- a/frontend/src/views/Register.vue
+++ b/frontend/src/views/Register.vue
@@ -18,12 +18,11 @@
 
               <v-form ref="formRef" v-model="formValid">
                 <v-text-field
-                  v-model="cpf"
-                  label="CPF"
+                  v-model="username"
+                  label="Usuário"
                   prepend-inner-icon="mdi-account"
-                  maxlength="14"
                   outlined
-                  :rules="[rules.required, rules.cpf]"
+                  :rules="[rules.required]"
                   class="mb-4"
                 ></v-text-field>
 
@@ -77,7 +76,7 @@
 import { ref } from 'vue'
 import { registerUser } from '../services/api'
 
-const cpf = ref('')
+const username = ref('')
 const email = ref('')
 const senha = ref('')
 const formRef = ref(null)
@@ -86,16 +85,12 @@ const year = new Date().getFullYear()
 
 const rules = {
   required: v => !!v || 'Campo obrigatório',
-  email: v => /.+@.+\..+/.test(String(v)) || 'E-mail inválido',
-  cpf: v => {
-    const digits = String(v || '').replace(/\D/g, '')
-    return digits.length === 11 || 'CPF inválido'
-  }
+  email: v => /.+@.+\..+/.test(String(v)) || 'E-mail inválido'
 }
 
 function register() {
   if (!formRef.value?.validate()) return
-  registerUser({ username: cpf.value, email: email.value, password: senha.value })
+  registerUser({ username: username.value, email: email.value, password: senha.value })
     .then(() => console.log('registrado'))
     .catch(err => console.error(err))
 }


### PR DESCRIPTION
## Summary
- adjust backend login to authenticate via email
- update Login and Register views to match new email/username fields

## Testing
- `npm test` *(fails: Missing script)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6852b41a7e0c832e8a64cf8838527e15