### PR TITLE
Fix login route to accept username or email

### DIFF
--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -20,11 +20,20 @@ def register():
 
 @bp.route('/login', methods=['POST'])
 def login():
-    data = request.get_json()
-    user = User.query.filter_by(email=data['email']).first()
+    data = request.get_json() or {}
+
+    # Accept both "email" and "username" fields to identify the user
+    identifier = data.get('email') or data.get('username')
+    if not identifier or 'password' not in data:
+        return jsonify({'msg': 'Credenciais inválidas.'}), 400
+
+    query_field = 'email' if 'email' in data else 'username'
+    user = User.query.filter_by(**{query_field: identifier}).first()
+
     if user and user.check_password(data['password']):
         access_token = create_access_token(identity=str(user.id))
         return jsonify(access_token=access_token)
+
     return jsonify({'msg': 'Usuário ou senha inválidos'}), 401
 
 @bp.route('/me', methods=['GET'])


### PR DESCRIPTION
## Summary
- support login with username or email to prevent KeyError on missing field

## Testing
- `python -m py_compile backend/app/routes/auth.py`


------
https://chatgpt.com/codex/tasks/task_e_6852b83feec8832e90ad52abe535c4e6