### PR TITLE
Add success message after registration

### DIFF
--- a/frontend/src/views/Register.vue
+++ b/frontend/src/views/Register.vue
@@ -61,6 +61,9 @@
                   </v-btn>
                 </router-link>
               </v-form>
+              <v-snackbar v-model="snackbar" color="success">
+                {{ snackbarMsg }}
+              </v-snackbar>
 
               <v-card-subtitle class="text-center mt-6 caption">
                 © {{ year }} Polícia Rodoviária Federal
@@ -74,6 +77,7 @@
 
 <script setup>
 import { ref } from 'vue'
+import { useRouter } from 'vue-router'
 import { registerUser } from '../services/api'
 
 const username = ref('')
@@ -82,6 +86,9 @@ const senha = ref('')
 const formRef = ref(null)
 const formValid = ref(false)
 const year = new Date().getFullYear()
+const snackbar = ref(false)
+const snackbarMsg = ref('')
+const router = useRouter()
 
 const rules = {
   required: v => !!v || 'Campo obrigatório',
@@ -91,7 +98,11 @@ const rules = {
 function register() {
   if (!formRef.value?.validate()) return
   registerUser({ username: username.value, email: email.value, password: senha.value })
-    .then(() => console.log('registrado'))
+    .then(() => {
+      snackbarMsg.value = 'Cadastro realizado com sucesso'
+      snackbar.value = true
+      setTimeout(() => router.push('/login'), 1500)
+    })
     .catch(err => console.error(err))
 }
 </script>


### PR DESCRIPTION
## Summary
- show a snackbar with a success message after completing registration
- redirect users to the login page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6852c88f8228832e8cb2b71c25edc20e