### PR TITLE
Implement admin user management page

### DIFF
--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -52,3 +52,34 @@ def get_users():
         for u in users
     ]
     return jsonify(user_list), 200
+
+
+@bp.route('/users/<int:user_id>', methods=['GET'])
+@jwt_required()
+def get_user(user_id):
+    user = User.query.get_or_404(user_id)
+    return jsonify(id=user.id, username=user.username, email=user.email), 200
+
+
+@bp.route('/users/<int:user_id>', methods=['PUT'])
+@jwt_required()
+def update_user(user_id):
+    user = User.query.get_or_404(user_id)
+    data = request.get_json() or {}
+    if 'username' in data:
+        user.username = data['username']
+    if 'email' in data:
+        user.email = data['email']
+    if data.get('password'):
+        user.set_password(data['password'])
+    db.session.commit()
+    return jsonify({'msg': 'Usuário atualizado com sucesso.'}), 200
+
+
+@bp.route('/users/<int:user_id>', methods=['DELETE'])
+@jwt_required()
+def delete_user(user_id):
+    user = User.query.get_or_404(user_id)
+    db.session.delete(user)
+    db.session.commit()
+    return jsonify({'msg': 'Usuário removido com sucesso.'}), 200

--- a/frontend/src/components/Header.vue
+++ b/frontend/src/components/Header.vue
@@ -11,9 +11,9 @@
       </template>
       <v-list>
         <v-list-item>
-          <v-list-item-title>{{ user.name }}</v-list-item-title>
+          <v-list-item-title>{{ user.username }}</v-list-item-title>
         </v-list-item>
-        <v-list-item link>
+        <v-list-item link :to="'/admin/users'">
           <v-list-item-title>Administradores</v-list-item-title>
         </v-list-item>
         <v-list-item @click="$emit('logout')">

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -2,11 +2,13 @@ import { createRouter, createWebHistory } from 'vue-router';
 import Login from '../views/Login.vue';
 import Register from '../views/Register.vue';
 import Home from '../views/Home.vue';
+import AdminUsers from '../views/AdminUsers.vue';
 
 const routes = [
   { path: '/login', component: Login, meta: { layout: 'auth' } },
   { path: '/register', component: Register, meta: { layout: 'auth' } },
-  { path: '/', component: Home }
+  { path: '/', component: Home },
+  { path: '/admin/users', component: AdminUsers }
 ];
 
 const router = createRouter({

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -24,4 +24,20 @@ export function fetchCurrentUser() {
   return api.get('/auth/me');
 }
 
+export function fetchUsers() {
+  return api.get('/auth/users');
+}
+
+export function fetchUser(id) {
+  return api.get(`/auth/users/${id}`);
+}
+
+export function updateUser(id, payload) {
+  return api.put(`/auth/users/${id}`, payload);
+}
+
+export function deleteUser(id) {
+  return api.delete(`/auth/users/${id}`);
+}
+
 export default api;

--- a/frontend/src/views/AdminUsers.vue
+++ b/frontend/src/views/AdminUsers.vue
@@ -1,0 +1,93 @@
+<template>
+  <v-container>
+    <v-card>
+      <v-card-title>Usuários cadastrados</v-card-title>
+      <v-data-table :items="users" :headers="headers" item-key="id">
+        <template #item.actions="{ item }">
+          <v-btn icon="mdi-pencil" size="small" @click="openEdit(item)" />
+          <v-btn icon="mdi-delete" size="small" color="red" @click="removeUser(item)" />
+        </template>
+      </v-data-table>
+    </v-card>
+
+    <v-dialog v-model="editDialog" max-width="400">
+      <v-card>
+        <v-card-title>Editar usuário</v-card-title>
+        <v-card-text>
+          <v-form ref="formRef" v-model="formValid">
+            <v-text-field
+              v-model="editUser.username"
+              label="Usuário"
+              :rules="[rules.required]"
+            ></v-text-field>
+            <v-text-field
+              v-model="editUser.email"
+              label="Email"
+              :rules="[rules.required, rules.email]"
+            ></v-text-field>
+            <v-text-field
+              v-model="editUser.password"
+              label="Senha"
+              type="password"
+            ></v-text-field>
+          </v-form>
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn text @click="editDialog = false">Cancelar</v-btn>
+          <v-btn color="primary" :disabled="!formValid" @click="saveEdit">Salvar</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+  </v-container>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import { fetchUsers, updateUser, deleteUser } from '../services/api'
+
+const users = ref([])
+const editDialog = ref(false)
+const editUser = ref({ id: null, username: '', email: '', password: '' })
+const formRef = ref(null)
+const formValid = ref(false)
+
+const headers = [
+  { title: 'ID', key: 'id' },
+  { title: 'Usuário', key: 'username' },
+  { title: 'Email', key: 'email' },
+  { title: 'Ações', key: 'actions', sortable: false },
+]
+
+const rules = {
+  required: v => !!v || 'Campo obrigatório',
+  email: v => /.+@.+\..+/.test(String(v)) || 'E-mail inválido',
+}
+
+async function loadUsers() {
+  const { data } = await fetchUsers()
+  users.value = data
+}
+
+function openEdit(item) {
+  editUser.value = { id: item.id, username: item.username, email: item.email, password: '' }
+  editDialog.value = true
+}
+
+async function saveEdit() {
+  if (!formRef.value?.validate()) return
+  const payload = { username: editUser.value.username, email: editUser.value.email }
+  if (editUser.value.password) payload.password = editUser.value.password
+  await updateUser(editUser.value.id, payload)
+  editDialog.value = false
+  await loadUsers()
+}
+
+async function removeUser(item) {
+  if (!confirm('Confirma remover este usuário?')) return
+  await deleteUser(item.id)
+  await loadUsers()
+}
+
+onMounted(loadUsers)
+</script>


### PR DESCRIPTION
## Summary
- extend auth routes with full user CRUD
- add admin users route
- link admin page in header
- expose user APIs to frontend
- implement AdminUsers view for editing users

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852ce528664832ea16bc0e05aead156