### PR TITLE
Add delete confirmation dialog for AdminUsers

### DIFF
--- a/frontend/src/views/AdminUsers.vue
+++ b/frontend/src/views/AdminUsers.vue
@@ -46,6 +46,18 @@
         </v-card-actions>
       </v-card>
     </v-dialog>
+
+    <v-dialog v-model="deleteDialog" max-width="400">
+      <v-card>
+        <v-card-title>Remover usuário</v-card-title>
+        <v-card-text>Confirma remover este usuário?</v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn text @click="deleteDialog = false">Cancelar</v-btn>
+          <v-btn color="red" @click="confirmDelete">Remover</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
   </v-container>
 </template>
 
@@ -55,6 +67,8 @@ import { fetchUsers, updateUser, deleteUser } from '../services/api'
 
 const users = ref([])
 const editDialog = ref(false)
+const deleteDialog = ref(false)
+const deleteId = ref(null)
 const editUser = ref({ id: null, username: '', email: '', administrador: false, password: '' })
 const formRef = ref(null)
 const formValid = ref(false)
@@ -92,9 +106,14 @@ async function saveEdit() {
   await loadUsers()
 }
 
-async function removeUser(item) {
-  if (!confirm('Confirma remover este usuário?')) return
-  await deleteUser(item.id)
+function removeUser(item) {
+  deleteId.value = item.id
+  deleteDialog.value = true
+}
+
+async function confirmDelete() {
+  await deleteUser(deleteId.value)
+  deleteDialog.value = false
   await loadUsers()
 }
 


### PR DESCRIPTION
## Summary
- add a Vuetify dialog to confirm user deletion
- introduce `confirmDelete` method for removing a user
- keep user list up to date after deletion

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6852d73f21cc832e8fde51ad93c670ba