### PR TITLE
Update API user endpoints

### DIFF
--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -25,19 +25,23 @@ export function fetchCurrentUser() {
 }
 
 export function fetchUsers() {
-  return api.get('api/auth/users');
+  return api.get('/api/auth/users');
+}
+
+export function createUser(payload) {
+  return api.post('/api/auth/users', payload);
 }
 
 export function fetchUser(id) {
-  return api.get(`api/auth/users/${id}`);
+  return api.get(`/api/auth/users/${id}`);
 }
 
 export function updateUser(id, payload) {
-  return api.put(`api/auth/users/${id}`, payload);
+  return api.put(`/api/auth/users/${id}`, payload);
 }
 
 export function deleteUser(id) {
-  return api.delete(`api/auth/users/${id}`);
+  return api.delete(`/api/auth/users/${id}`);
 }
 
 export default api;


### PR DESCRIPTION
## Summary
- fix auth user API paths to `/api/auth/users`
- add `createUser` function

## Testing
- `npm -v`


------
https://chatgpt.com/codex/tasks/task_e_6852f7f82544832e88fd86a0bd98f941