### PR TITLE
Display logged user name

### DIFF
--- a/frontend/src/components/Header.vue
+++ b/frontend/src/components/Header.vue
@@ -5,8 +5,9 @@
     <v-spacer></v-spacer>
     <v-menu v-if="user" offset-y>
       <template #activator="{ props }">
-        <v-btn v-bind="props" icon>
-          <v-icon>mdi-account</v-icon>
+        <v-btn v-bind="props" class="d-flex align-center" variant="text">
+          <v-icon class="mr-1">mdi-account-circle</v-icon>
+          <span>{{ user.username }}</span>
         </v-btn>
       </template>
       <v-list>


### PR DESCRIPTION
## Summary
- show the username next to the user icon in the header
- use mdi-account-circle icon

## Testing
- `npm run build` *(fails: vue-cli-service not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853083f2360832eb55b3412d70c8e20