### PR TITLE
Adiciona grupos de navegação ao Sidebar

### DIFF
--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -1,18 +1,54 @@
 <template>
-  <v-navigation-drawer v-model="drawer" color="#f5f5f5">    
-      <v-list-item dense>
-        <v-list-item-content >              
-          <v-list-item-title class="text-h6">
-            PRF
-          </v-list-item-title>
-          <v-list-item-subtitle>
-            NPI-RS
-          </v-list-item-subtitle>
-        </v-list-item-content>
-      </v-list-item>
-      
-      <v-divider></v-divider> 
-    
+  <v-navigation-drawer v-model="drawer" color="#f5f5f5">
+    <v-list-item dense>
+      <v-list-item-content>
+        <v-list-item-title class="text-h6">PRF</v-list-item-title>
+        <v-list-item-subtitle>NPI-RS</v-list-item-subtitle>
+      </v-list-item-content>
+    </v-list-item>
+
+    <v-divider></v-divider>
+
+    <v-list density="compact" nav>
+      <v-list-group value="autoprf">
+        <template #activator="{ props }">
+          <v-list-item
+            v-bind="props"
+            prepend-icon="mdi-car"
+            title="AutoPRF"
+          />
+        </template>
+        <v-list-item title="Teste1" prepend-icon="mdi-file" />
+        <v-list-item title="Teste2" prepend-icon="mdi-file" />
+        <v-list-item title="Teste3" prepend-icon="mdi-file" />
+      </v-list-group>
+
+      <v-list-group value="siscom">
+        <template #activator="{ props }">
+          <v-list-item
+            v-bind="props"
+            prepend-icon="mdi-laptop"
+            title="SISCOM"
+          />
+        </template>
+        <v-list-item title="Teste1" prepend-icon="mdi-file" />
+        <v-list-item title="Teste2" prepend-icon="mdi-file" />
+        <v-list-item title="Teste3" prepend-icon="mdi-file" />
+      </v-list-group>
+
+      <v-list-group value="sei">
+        <template #activator="{ props }">
+          <v-list-item
+            v-bind="props"
+            prepend-icon="mdi-file-document"
+            title="SEI"
+          />
+        </template>
+        <v-list-item title="Teste1" prepend-icon="mdi-file" />
+        <v-list-item title="Teste2" prepend-icon="mdi-file" />
+        <v-list-item title="Teste3" prepend-icon="mdi-file" />
+      </v-list-group>
+    </v-list>
   </v-navigation-drawer>
 </template>
 


### PR DESCRIPTION
## Summary
- adiciona grupos AutoPRF, SISCOM e SEI no componente `Sidebar`
- cada grupo possui subopções teste1, teste2 e teste3 com ícones

## Testing
- `npm run build`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685329c07318832e92711b2fea1a37df