### PR TITLE
Add icons to header menu items

### DIFF
--- a/frontend/src/components/Header.vue
+++ b/frontend/src/components/Header.vue
@@ -19,10 +19,15 @@
         </v-btn>
       </template>
       <v-list>        
-        <v-list-item v-if="user.administrador" link :to="'/admin/users'">
+        <v-list-item
+          v-if="user.administrador"
+          link
+          :to="'/admin/users'"
+          prepend-icon="mdi-cog"
+        >
           <v-list-item-title>Administração</v-list-item-title>
         </v-list-item>
-        <v-list-item @click="$emit('logout')">
+        <v-list-item prepend-icon="mdi-logout" @click="$emit('logout')">
           <v-list-item-title>Logout</v-list-item-title>
         </v-list-item>
       </v-list>


### PR DESCRIPTION
## Summary
- add icons for admin and logout options in the header dropdown menu

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68532ca295cc832ea67083cddf7bfaf1