### PR TITLE
Add router auth guard and login error display

### DIFF
--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -1,19 +1,30 @@
-import { createRouter, createWebHistory } from 'vue-router';
-import Login from '../views/Login.vue';
-import Register from '../views/Register.vue';
-import Home from '../views/Home.vue';
-import AdminUsers from '../views/AdminUsers.vue';
+import { createRouter, createWebHistory } from 'vue-router'
+import Login from '../views/Login.vue'
+import Register from '../views/Register.vue'
+import Home from '../views/Home.vue'
+import AdminUsers from '../views/AdminUsers.vue'
+import store from '../store'
 
 const routes = [
   { path: '/login', component: Login, meta: { layout: 'auth' } },
   { path: '/register', component: Register, meta: { layout: 'auth' } },
-  { path: '/', component: Home },
-  { path: '/admin/users', component: AdminUsers }
-];
+  { path: '/', component: Home, meta: { requiresAuth: true } },
+  { path: '/admin/users', component: AdminUsers, meta: { requiresAuth: true } },
+  { path: '/:pathMatch(.*)*', redirect: '/login?error=not_found' }
+]
 
 const router = createRouter({
   history: createWebHistory(),
   routes
-});
+
+})
+
+router.beforeEach((to, from, next) => {
+  if (to.meta.requiresAuth && !store.state.token) {
+    next('/login?error=unauthorized')
+  } else {
+    next()
+  }
+})
 
 export default router;

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -83,8 +83,8 @@
 </template>
 
 <script setup>
-import { ref } from 'vue'
-import { useRouter } from 'vue-router'
+import { ref, onMounted, watch } from 'vue'
+import { useRouter, useRoute } from 'vue-router'
 import { useStore } from 'vuex'
 import { loginUser } from '../services/api'
 
@@ -94,6 +94,7 @@ const formRef = ref(null)
 const formValid = ref(false)
 const year = new Date().getFullYear()
 const router = useRouter()
+const route = useRoute()
 const store = useStore()
 const successSnackbar = ref(false)
 const successMsg = ref('')
@@ -119,6 +120,30 @@ async function login() {
     console.error(err)
   }
 }
+
+function handleQueryError(error) {
+  if (error === 'unauthorized') {
+    errorMsg.value = 'Faça login para continuar'
+  } else if (error === 'not_found') {
+    errorMsg.value = 'Página não encontrada'
+  } else {
+    errorMsg.value = 'Erro desconhecido'
+  }
+  errorSnackbar.value = true
+}
+
+onMounted(() => {
+  if (route.query.error) {
+    handleQueryError(route.query.error)
+  }
+})
+
+watch(
+  () => route.query.error,
+  val => {
+    if (val) handleQueryError(val)
+  }
+)
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Summary
- protect authenticated routes with `requiresAuth` meta data
- redirect unauthorized or unknown paths to `/login` with query params
- show snackbar messages on `/login` based on route query

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68533dda705c832e906714c13782ea85