### PR TITLE
Add cpf fields and hashes

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -7,9 +7,33 @@ class User(db.Model):
     password_hash = db.Column(db.String(120), nullable=False)
     email = db.Column(db.String(120), unique=True, nullable=False)
     administrador = db.Column(db.Boolean, default=False)
+    cpf = db.Column(db.String(14), unique=True)
+    senha_autoprf_hash = db.Column('senha_autoprf', db.String(120))
+    token_autoprf = db.Column(db.String(120))
+    senha_siscom_hash = db.Column('senha_siscom', db.String(120))
+    senha_sei_hash = db.Column('senha_sei', db.String(120))
+    token_sei = db.Column(db.String(120))
 
     def set_password(self, password):
         self.password_hash = generate_password_hash(password)
-    
+
     def check_password(self, password):
         return check_password_hash(self.password_hash, password)
+
+    def set_senha_autoprf(self, password):
+        self.senha_autoprf_hash = generate_password_hash(password)
+
+    def check_senha_autoprf(self, password):
+        return check_password_hash(self.senha_autoprf_hash or '', password)
+
+    def set_senha_siscom(self, password):
+        self.senha_siscom_hash = generate_password_hash(password)
+
+    def check_senha_siscom(self, password):
+        return check_password_hash(self.senha_siscom_hash or '', password)
+
+    def set_senha_sei(self, password):
+        self.senha_sei_hash = generate_password_hash(password)
+
+    def check_senha_sei(self, password):
+        return check_password_hash(self.senha_sei_hash or '', password)

--- a/backend/migrations/versions/4f67b9f9475c_add_cpf_and_passwords.py
+++ b/backend/migrations/versions/4f67b9f9475c_add_cpf_and_passwords.py
@@ -1,0 +1,33 @@
+"""add cpf and auth credentials
+
+Revision ID: 4f67b9f9475c
+Revises: 9c77cf571a1d
+Create Date: 2025-07-01 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '4f67b9f9475c'
+down_revision = '9c77cf571a1d'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('user', sa.Column('cpf', sa.String(length=14), nullable=True))
+    op.add_column('user', sa.Column('senha_autoprf', sa.String(length=120), nullable=True))
+    op.add_column('user', sa.Column('token_autoprf', sa.String(length=120), nullable=True))
+    op.add_column('user', sa.Column('senha_siscom', sa.String(length=120), nullable=True))
+    op.add_column('user', sa.Column('senha_sei', sa.String(length=120), nullable=True))
+    op.add_column('user', sa.Column('token_sei', sa.String(length=120), nullable=True))
+
+
+def downgrade():
+    op.drop_column('user', 'token_sei')
+    op.drop_column('user', 'senha_sei')
+    op.drop_column('user', 'senha_siscom')
+    op.drop_column('user', 'token_autoprf')
+    op.drop_column('user', 'senha_autoprf')
+    op.drop_column('user', 'cpf')

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -19,9 +19,11 @@
             title="AutoPRF"
           />
         </template>
-        <v-list-item title="Teste1" prepend-icon="mdi-file" />
-        <v-list-item title="Teste2" prepend-icon="mdi-file" />
-        <v-list-item title="Teste3" prepend-icon="mdi-file" />
+        <v-list-item
+          title="Autenticação"
+          prepend-icon="mdi-lock"
+          @click="autoprfDialog = true"
+        />
       </v-list-group>
 
       <v-list-group value="siscom">
@@ -32,9 +34,11 @@
             title="SISCOM"
           />
         </template>
-        <v-list-item title="Teste1" prepend-icon="mdi-file" />
-        <v-list-item title="Teste2" prepend-icon="mdi-file" />
-        <v-list-item title="Teste3" prepend-icon="mdi-file" />
+        <v-list-item
+          title="Autenticação"
+          prepend-icon="mdi-lock"
+          @click="siscomDialog = true"
+        />
       </v-list-group>
 
       <v-list-group value="sei">
@@ -45,16 +49,70 @@
             title="SEI"
           />
         </template>
-        <v-list-item title="Teste1" prepend-icon="mdi-file" />
-        <v-list-item title="Teste2" prepend-icon="mdi-file" />
-        <v-list-item title="Teste3" prepend-icon="mdi-file" />
+        <v-list-item
+          title="Autenticação"
+          prepend-icon="mdi-lock"
+          @click="seiDialog = true"
+        />
       </v-list-group>
     </v-list>
+
+    <v-dialog v-model="autoprfDialog" max-width="400">
+      <v-card>
+        <v-card-title>Autenticação AutoPRF</v-card-title>
+        <v-card-text>
+          <v-form ref="autoprfForm" v-model="autoprfValid">
+            <v-text-field v-model="autoprfSenha" label="Senha AutoPRF" type="password" :rules="[rules.required]" />
+            <v-text-field v-model="autoprfToken" label="Token AutoPRF" />
+          </v-form>
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn text @click="autoprfDialog = false">Cancelar</v-btn>
+          <v-btn color="primary" :disabled="!autoprfValid" @click="saveAutoprf">Salvar</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <v-dialog v-model="siscomDialog" max-width="400">
+      <v-card>
+        <v-card-title>Autenticação SISCOM</v-card-title>
+        <v-card-text>
+          <v-form ref="siscomForm" v-model="siscomValid">
+            <v-text-field v-model="siscomSenha" label="Senha SISCOM" type="password" :rules="[rules.required]" />
+          </v-form>
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn text @click="siscomDialog = false">Cancelar</v-btn>
+          <v-btn color="primary" :disabled="!siscomValid" @click="saveSiscom">Salvar</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <v-dialog v-model="seiDialog" max-width="400">
+      <v-card>
+        <v-card-title>Autenticação SEI</v-card-title>
+        <v-card-text>
+          <v-form ref="seiForm" v-model="seiValid">
+            <v-text-field v-model="seiSenha" label="Senha SEI" type="password" :rules="[rules.required]" />
+            <v-text-field v-model="seiToken" label="Token SEI" />
+          </v-form>
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn text @click="seiDialog = false">Cancelar</v-btn>
+          <v-btn color="primary" :disabled="!seiValid" @click="saveSei">Salvar</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
   </v-navigation-drawer>
 </template>
 
 <script setup>
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
+import { useStore } from 'vuex'
+import { updateUser } from '../services/api'
 
 const props = defineProps({
   modelValue: {
@@ -68,4 +126,53 @@ const drawer = computed({
   get: () => props.modelValue,
   set: val => emit('update:modelValue', val)
 })
+
+const store = useStore()
+
+const autoprfDialog = ref(false)
+const siscomDialog = ref(false)
+const seiDialog = ref(false)
+
+const autoprfSenha = ref('')
+const autoprfToken = ref('')
+const siscomSenha = ref('')
+const seiSenha = ref('')
+const seiToken = ref('')
+
+const autoprfForm = ref(null)
+const autoprfValid = ref(false)
+const siscomForm = ref(null)
+const siscomValid = ref(false)
+const seiForm = ref(null)
+const seiValid = ref(false)
+
+const rules = {
+  required: v => !!v || 'Campo obrigatório'
+}
+
+async function saveAutoprf() {
+  if (!autoprfForm.value?.validate()) return
+  await updateUser(store.state.user.id, {
+    senha_autoprf: autoprfSenha.value,
+    token_autoprf: autoprfToken.value
+  })
+  autoprfDialog.value = false
+}
+
+async function saveSiscom() {
+  if (!siscomForm.value?.validate()) return
+  await updateUser(store.state.user.id, {
+    senha_siscom: siscomSenha.value
+  })
+  siscomDialog.value = false
+}
+
+async function saveSei() {
+  if (!seiForm.value?.validate()) return
+  await updateUser(store.state.user.id, {
+    senha_sei: seiSenha.value,
+    token_sei: seiToken.value
+  })
+  seiDialog.value = false
+}
 </script>

--- a/frontend/src/views/AdminUsers.vue
+++ b/frontend/src/views/AdminUsers.vue
@@ -31,6 +31,10 @@
               label="Email"
               :rules="[rules.required, rules.email]"
             ></v-text-field>
+            <v-text-field
+              v-model="editUser.cpf"
+              label="CPF"
+            ></v-text-field>
             <v-checkbox
               v-model="editUser.administrador"
               label="Administrador"
@@ -64,6 +68,10 @@
               v-model="newUser.email"
               label="Email"
               :rules="[rules.required, rules.email]"
+            ></v-text-field>
+            <v-text-field
+              v-model="newUser.cpf"
+              label="CPF"
             ></v-text-field>
             <v-text-field
               v-model="newUser.password"
@@ -115,8 +123,8 @@
   const createDialog = ref(false)
   const deleteDialog = ref(false)
   const deleteId = ref(null)
-  const editUser = ref({ id: null, username: '', email: '', administrador: false, password: '' })
-  const newUser = ref({ username: '', email: '', password: '', administrador: false })
+  const editUser = ref({ id: null, username: '', email: '', cpf: '', administrador: false, password: '' })
+  const newUser = ref({ username: '', email: '', cpf: '', password: '', administrador: false })
   const formRef = ref(null)
   const formValid = ref(false)
   const createFormRef = ref(null)
@@ -129,6 +137,7 @@
     { title: 'ID', key: 'id' },
     { title: 'Usuário', key: 'username' },
     { title: 'Email', key: 'email' },
+    { title: 'CPF', key: 'cpf' },
     { title: 'Administrador', key: 'administrador' },
     { title: 'Ações', key: 'actions', sortable: false },
   ]
@@ -150,14 +159,19 @@
   }
 
   function openCreate() {
-    newUser.value = { username: '', email: '', password: '', administrador: false }
+    newUser.value = { username: '', email: '', cpf: '', password: '', administrador: false }
     createFormValid.value = false
     createDialog.value = true
   }
 
   async function saveCreate() {
     if (!createFormRef.value?.validate()) return
-    const payload = { username: newUser.value.username, email: newUser.value.email, password: newUser.value.password }
+    const payload = {
+      username: newUser.value.username,
+      email: newUser.value.email,
+      cpf: newUser.value.cpf,
+      password: newUser.value.password
+    }
     payload.administrador = newUser.value.administrador
     try {
       await createUser(payload)
@@ -174,13 +188,24 @@
   }
 
   function openEdit(item) {
-    editUser.value = { id: item.id, username: item.username, email: item.email, administrador: item.administrador, password: '' }
+    editUser.value = {
+      id: item.id,
+      username: item.username,
+      email: item.email,
+      cpf: item.cpf,
+      administrador: item.administrador,
+      password: ''
+    }
     editDialog.value = true
   }
 
   async function saveEdit() {
     if (!formRef.value?.validate()) return
-    const payload = { username: editUser.value.username, email: editUser.value.email }
+    const payload = {
+      username: editUser.value.username,
+      email: editUser.value.email,
+      cpf: editUser.value.cpf
+    }
     payload.administrador = editUser.value.administrador
     if (editUser.value.password) payload.password = editUser.value.password
     try {

--- a/frontend/src/views/Register.vue
+++ b/frontend/src/views/Register.vue
@@ -36,6 +36,15 @@
                 ></v-text-field>
 
                 <v-text-field
+                  v-model="cpf"
+                  label="CPF"
+                  prepend-inner-icon="mdi-card-account-details"
+                  outlined
+                  :rules="[rules.required]"
+                  class="mb-4"
+                ></v-text-field>
+
+                <v-text-field
                   v-model="senha"
                   label="Senha"
                   prepend-inner-icon="mdi-lock"
@@ -96,6 +105,7 @@ import { registerUser } from '../services/api'
 
 const username = ref('')
 const email = ref('')
+const cpf = ref('')
 const senha = ref('')
 const formRef = ref(null)
 const formValid = ref(false)
@@ -114,7 +124,12 @@ const rules = {
 async function register() {
   if (!formRef.value?.validate()) return
   try {
-    await registerUser({ username: username.value, email: email.value, password: senha.value })
+    await registerUser({
+      username: username.value,
+      email: email.value,
+      cpf: cpf.value,
+      password: senha.value
+    })
     snackbarMsg.value = 'Cadastro realizado com sucesso'
     snackbar.value = true
   } catch (err) {


### PR DESCRIPTION
## Summary
- store cpf, senha_autoprf, token_autoprf, senha_siscom, senha_sei and token_sei for each user
- expose cpf in admin user API responses
- allow admins to edit cpf and credentials via API
- add authentication dialogs in the sidebar
- require cpf on registration

## Testing
- `python -m py_compile backend/app/*.py backend/app/routes/*.py backend/app/utils/*.py backend/*.py backend/migrations/versions/*.py`
- `npm --version`


------
https://chatgpt.com/codex/tasks/task_e_68534cfce920832e80d6d7a6f2d84911