### PR TITLE
Implement AutoPRF login trigger

### DIFF
--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -121,7 +121,7 @@
 <script setup>
 import { computed, ref } from 'vue'
 import { useStore } from 'vuex'
-import { updateUser } from '../services/api'
+import { updateUser, autoprfLogin } from '../services/api'
 
 const props = defineProps({
   modelValue: {
@@ -167,6 +167,10 @@ async function saveAutoprf() {
   if (!autoprfForm.value?.validate()) return
   try {
     await updateUser(store.state.user.id, {
+      senha_autoprf: autoprfSenha.value,
+      token_autoprf: autoprfToken.value
+    })
+    await autoprfLogin({
       senha_autoprf: autoprfSenha.value,
       token_autoprf: autoprfToken.value
     })

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -44,4 +44,8 @@ export function deleteUser(id) {
   return api.delete(`/api/auth/users/${id}`);
 }
 
+export function autoprfLogin(payload) {
+  return api.post('/api/autoprf/login', payload);
+}
+
 export default api;


### PR DESCRIPTION
## Summary
- provide API helper to call `/api/autoprf/login`
- invoke AutoPRF login from sidebar authentication dialog

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68544b18af9c832e87d48800a574b9bd