### PR TITLE
Add search option for AutoPRF

### DIFF
--- a/backend/app/routes/autoprf.py
+++ b/backend/app/routes/autoprf.py
@@ -13,15 +13,18 @@ bp = Blueprint('autoprf', __name__, url_prefix='/api/autoprf')
 def login():
     user = User.query.get_or_404(get_jwt_identity())
     data = request.get_json() or {}
-    password = data.get('senha_autoprf')
-    token = data.get('token_autoprf')
+    password = data.get('senha_autoprf') or data.get('password')
+    token = data.get('token_autoprf') or data.get('token')
     if not password or not token:
         return jsonify({'msg': 'Credenciais inválidas'}), 400
 
     client = AutoPRFClient()
     cookies = client.login(user.cpf, password, token)
 
-    user.autoprf_session = json.dumps(cookies)  # salva como texto
+    if isinstance(cookies, str):
+        user.autoprf_session = cookies
+    else:
+        user.autoprf_session = json.dumps(cookies)
     db.session.commit()
     return jsonify({'cookies': cookies}), 200
 

--- a/backend/app/utils/autoprf.py
+++ b/backend/app/utils/autoprf.py
@@ -5,7 +5,7 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.chrome.service import Service
 from flask import current_app
-from scraping_utils import carregar_cookies
+from .scraping_utils import carregar_cookies
 
 class AutoPRFClient:
     def __init__(self):

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -24,6 +24,11 @@
           prepend-icon="mdi-lock"
           @click="autoprfDialog = true"
         />
+        <v-list-item
+          title="Pesquisar AI"
+          prepend-icon="mdi-magnify"
+          @click="autoprfPesquisaDialog = true"
+        />
       </v-list-group>
 
       <v-list-group value="siscom">
@@ -57,22 +62,38 @@
       </v-list-group>
     </v-list>
 
-    <v-dialog v-model="autoprfDialog" max-width="400">
-      <v-card>
-        <v-card-title>Autenticação AutoPRF</v-card-title>
-        <v-card-text>
-          <v-form ref="autoprfForm" v-model="autoprfValid">
-            <v-text-field v-model="autoprfSenha" label="Senha AutoPRF" type="password" :rules="[rules.required]" />
-            <v-text-field v-model="autoprfToken" label="Token AutoPRF" />
-          </v-form>
-        </v-card-text>
-        <v-card-actions>
-          <v-spacer />
-          <v-btn text @click="autoprfDialog = false">Cancelar</v-btn>
-          <v-btn color="primary" :disabled="!autoprfValid" @click="saveAutoprf">Salvar</v-btn>
-        </v-card-actions>
-      </v-card>
-    </v-dialog>
+      <v-dialog v-model="autoprfDialog" max-width="400">
+        <v-card>
+          <v-card-title>Autenticação AutoPRF</v-card-title>
+          <v-card-text>
+            <v-form ref="autoprfForm" v-model="autoprfValid">
+              <v-text-field v-model="autoprfSenha" label="Senha AutoPRF" type="password" :rules="[rules.required]" />
+              <v-text-field v-model="autoprfToken" label="Token AutoPRF" />
+            </v-form>
+          </v-card-text>
+          <v-card-actions>
+            <v-spacer />
+            <v-btn text @click="autoprfDialog = false">Cancelar</v-btn>
+            <v-btn color="primary" :disabled="!autoprfValid" @click="saveAutoprf">Salvar</v-btn>
+          </v-card-actions>
+        </v-card>
+      </v-dialog>
+
+      <v-dialog v-model="autoprfPesquisaDialog" max-width="400">
+        <v-card>
+          <v-card-title>Pesquisar Auto de Infração</v-card-title>
+          <v-card-text>
+            <v-form ref="autoprfPesquisaForm" v-model="autoprfPesquisaValid">
+              <v-text-field v-model="autoInfracao" label="Número do AI" :rules="[rules.required]" />
+            </v-form>
+          </v-card-text>
+          <v-card-actions>
+            <v-spacer />
+            <v-btn text @click="autoprfPesquisaDialog = false">Cancelar</v-btn>
+            <v-btn color="primary" :disabled="!autoprfPesquisaValid" @click="pesquisarAI">Pesquisar</v-btn>
+          </v-card-actions>
+        </v-card>
+      </v-dialog>
 
     <v-dialog v-model="siscomDialog" max-width="400">
       <v-card>
@@ -121,7 +142,7 @@
 <script setup>
 import { computed, ref } from 'vue'
 import { useStore } from 'vuex'
-import { updateUser, autoprfLogin } from '../services/api'
+import { updateUser, autoprfLogin, pesquisarAutoInfracao } from '../services/api'
 
 const props = defineProps({
   modelValue: {
@@ -139,6 +160,7 @@ const drawer = computed({
 const store = useStore()
 
 const autoprfDialog = ref(false)
+const autoprfPesquisaDialog = ref(false)
 const siscomDialog = ref(false)
 const seiDialog = ref(false)
 
@@ -147,9 +169,12 @@ const autoprfToken = ref('')
 const siscomSenha = ref('')
 const seiSenha = ref('')
 const seiToken = ref('')
+const autoInfracao = ref('')
 
 const autoprfForm = ref(null)
 const autoprfValid = ref(false)
+const autoprfPesquisaForm = ref(null)
+const autoprfPesquisaValid = ref(false)
 const siscomForm = ref(null)
 const siscomValid = ref(false)
 const seiForm = ref(null)
@@ -180,6 +205,22 @@ async function saveAutoprf() {
     autoprfDialog.value = false
   } catch (err) {
     snackbarMsg.value = err.response?.data?.msg || 'Erro ao salvar dados AutoPRF'
+    snackbarColor.value = 'error'
+    snackbar.value = true
+  }
+}
+
+async function pesquisarAI() {
+  if (!autoprfPesquisaForm.value?.validate()) return
+  try {
+    await pesquisarAutoInfracao({ auto_infracao: autoInfracao.value })
+    snackbarMsg.value = 'Pesquisa enviada com sucesso'
+    snackbarColor.value = 'success'
+    snackbar.value = true
+    autoprfPesquisaDialog.value = false
+    autoInfracao.value = ''
+  } catch (err) {
+    snackbarMsg.value = err.response?.data?.msg || 'Erro ao pesquisar AI'
     snackbarColor.value = 'error'
     snackbar.value = true
   }

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -48,4 +48,8 @@ export function autoprfLogin(payload) {
   return api.post('/api/autoprf/login', payload);
 }
 
+export function pesquisarAutoInfracao(payload) {
+  return api.post('/api/autoprf/pesquisar_ai', payload);
+}
+
 export default api;


### PR DESCRIPTION
## Summary
- enable fallback credentials for AutoPRF login route
- adjust AutoPRF utils import path
- expose `pesquisarAutoInfracao` API method
- add sidebar entry and dialog for searching Auto de Infracao

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6854803af750832ebb7b80254edc707f