### PR TITLE
Atualiza AutoPRF para armazenar JWT

### DIFF
--- a/backend/app/routes/autoprf.py
+++ b/backend/app/routes/autoprf.py
@@ -1,4 +1,3 @@
-import json
 from flask import Blueprint, request, jsonify
 from flask_jwt_extended import jwt_required, get_jwt_identity
 
@@ -19,14 +18,11 @@ def login():
         return jsonify({'msg': 'Credenciais inválidas'}), 400
 
     client = AutoPRFClient()
-    cookies = client.login(user.cpf, password, token)
+    jwt_token = client.login(user.cpf, password, token)
 
-    if isinstance(cookies, str):
-        user.autoprf_session = cookies
-    else:
-        user.autoprf_session = json.dumps(cookies)
+    user.autoprf_session = jwt_token
     db.session.commit()
-    return jsonify({'cookies': cookies}), 200
+    return jsonify({'jwt': jwt_token}), 200
 
 @bp.route('/pesquisar_ai', methods=['POST'])
 @jwt_required()
@@ -41,7 +37,7 @@ def pesquisar_auto_infracao():
     if not auto_infracao:
         return jsonify({'msg': 'Número de Auto de Infração não informado'}), 400
 
-    client = AutoPRFClient(cookies_json=user.autoprf_session)
+    client = AutoPRFClient(jwt_token=user.autoprf_session)
     client.pesquisa_auto_infracao(auto_infracao)
 
     return jsonify({'msg': 'Pesquisa realizada com sucesso'})

--- a/backend/tests/test_autoprf.py
+++ b/backend/tests/test_autoprf.py
@@ -36,9 +36,9 @@ def test_autoprf_login_stores_session(client, app, monkeypatch):
         assert cpf == cpf_value
         assert password == "autoprf-pass"
         assert token == "123456"
-        return "cookie=value"
+        return "jwt-token"
 
-    def fake_init(self):
+    def fake_init(self, jwt_token=None):
         self.driver = None
 
     monkeypatch.setattr(AutoPRFClient, "__init__", fake_init)
@@ -54,4 +54,4 @@ def test_autoprf_login_stores_session(client, app, monkeypatch):
     assert response.status_code == 200
     with app.app_context():
         updated = User.query.get(user.id)
-        assert updated.autoprf_session == "cookie=value"
+        assert updated.autoprf_session == "jwt-token"


### PR DESCRIPTION
## Summary
- store JWT token returned from AutoPRF login instead of cookies
- pass JWT token to AutoPRFClient for further requests
- adjust AutoPRFClient implementation to capture token
- update unit test for JWT-based session

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854a4440f14832eb6bcef306915e3c5