### PR TITLE
Add global loading indicator

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -2,16 +2,21 @@
   <component :is="layout">
     <router-view />
   </component>
+  <LoadingOverlay v-if="loading" />
 </template>
 
 <script setup>
 import { computed } from 'vue'
 import { useRoute } from 'vue-router'
+import { useStore } from 'vuex'
 import MainLayout from './layouts/MainLayout.vue'
 import AuthLayout from './layouts/AuthLayout.vue'
+import LoadingOverlay from './components/LoadingOverlay.vue'
 
+const store = useStore()
 const route = useRoute()
 const layout = computed(() =>
   route.meta.layout === 'auth' ? AuthLayout : MainLayout
 )
+const loading = computed(() => store.state.loading)
 </script>

--- a/frontend/src/components/LoadingOverlay.vue
+++ b/frontend/src/components/LoadingOverlay.vue
@@ -1,0 +1,14 @@
+<template>
+  <v-overlay :model-value="true" class="loading-overlay d-flex align-center justify-center">
+    <v-progress-circular indeterminate size="64" color="primary" />
+  </v-overlay>
+</template>
+
+<script setup>
+</script>
+
+<style scoped>
+.loading-overlay {
+  background-color: rgba(255, 255, 255, 0.7);
+}
+</style>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -3,10 +3,12 @@ import App from './App.vue';
 import router from './router';
 import store from './store';
 import vuetify from './plugins/vuetify';
+import { setupLoadingInterceptors } from './services/api';
 
 const app = createApp(App);
 app.use(router);
 app.use(store);
+setupLoadingInterceptors(store);
 store.dispatch('initialize');
 app.use(vuetify);
 app.mount('#app');

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -52,4 +52,28 @@ export function pesquisarAutoInfracao(payload) {
   return api.post('/api/autoprf/pesquisar_ai', payload);
 }
 
+export function setupLoadingInterceptors(store) {
+  api.interceptors.request.use(
+    config => {
+      store.commit('setLoading', true);
+      return config;
+    },
+    error => {
+      store.commit('setLoading', false);
+      return Promise.reject(error);
+    }
+  );
+
+  api.interceptors.response.use(
+    response => {
+      store.commit('setLoading', false);
+      return response;
+    },
+    error => {
+      store.commit('setLoading', false);
+      return Promise.reject(error);
+    }
+  );
+}
+
 export default api;

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -5,7 +5,8 @@ export default createStore({
   state: {
     user: null,
     token: localStorage.getItem('token') || null,
-    aiResult: null
+    aiResult: null,
+    loading: false
   },
   mutations: {
     setToken(state, token) {
@@ -22,6 +23,9 @@ export default createStore({
     },
     setAiResult(state, data) {
       state.aiResult = data
+    },
+    setLoading(state, value) {
+      state.loading = value
     },
     logout(state) {
       state.user = null


### PR DESCRIPTION
## Summary
- track `loading` in store and expose a `setLoading` mutation
- register Axios interceptors to toggle loading state
- wire interceptors in main setup
- display a new `LoadingOverlay` component based on store

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6857fd1996ac832e97fc777026f6cf1b