### PR TITLE
Modularize frontend services

### DIFF
--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -162,7 +162,8 @@
 import { computed, ref } from 'vue'
 import { useStore } from 'vuex'
 import { useRouter } from 'vue-router'
-import { updateUser, autoprfLogin, pesquisarAutoInfracao } from '../services/api'
+import { updateUser } from '../services/users'
+import { autoprfLogin, pesquisarAutoInfracao } from '../services/autoprf'
 
 const props = defineProps({
   modelValue: {

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,9 +1,9 @@
-import axios from 'axios';
-import router from '../router';
+import axios from 'axios'
+import router from '../router'
 
 const api = axios.create({
   baseURL: 'http://localhost:5000'
-});
+})
 
 export function setToken(token) {
   if (token) {
@@ -13,49 +13,6 @@ export function setToken(token) {
   }
 }
 
-export function registerUser(payload) {
-  return api.post('/api/auth/register', payload);
-}
-
-export function loginUser(payload) {
-  return api.post('/api/auth/login', payload);
-}
-
-export function fetchCurrentUser() {
-  return api.get('/api/auth/me');
-}
-
-export function fetchUsers() {
-  return api.get('/api/auth/users');
-}
-
-export function createUser(payload) {
-  return api.post('/api/auth/users', payload);
-}
-
-export function fetchUser(id) {
-  return api.get(`/api/auth/users/${id}`);
-}
-
-export function updateUser(id, payload) {
-  return api.put(`/api/auth/users/${id}`, payload);
-}
-
-export function deleteUser(id) {
-  return api.delete(`/api/auth/users/${id}`);
-}
-
-export function autoprfLogin(payload) {
-  return api.post('/api/autoprf/login', payload);
-}
-
-export function pesquisarAutoInfracao(payload) {
-  return api.post('/api/autoprf/pesquisar_ai', payload);
-}
-
-export function obterEnvolvidos(id) {
-  return api.get(`/api/autoprf/envolvidos/${id}`);
-}
 
 export function setupLoadingInterceptors(store) {
   api.interceptors.request.use(

--- a/frontend/src/services/auth.js
+++ b/frontend/src/services/auth.js
@@ -1,0 +1,13 @@
+import api from './api'
+
+export function registerUser(payload) {
+  return api.post('/api/auth/register', payload)
+}
+
+export function loginUser(payload) {
+  return api.post('/api/auth/login', payload)
+}
+
+export function fetchCurrentUser() {
+  return api.get('/api/auth/me')
+}

--- a/frontend/src/services/autoprf.js
+++ b/frontend/src/services/autoprf.js
@@ -1,0 +1,13 @@
+import api from './api'
+
+export function autoprfLogin(payload) {
+  return api.post('/api/autoprf/login', payload)
+}
+
+export function pesquisarAutoInfracao(payload) {
+  return api.post('/api/autoprf/pesquisar_ai', payload)
+}
+
+export function obterEnvolvidos(id) {
+  return api.get(`/api/autoprf/envolvidos/${id}`)
+}

--- a/frontend/src/services/users.js
+++ b/frontend/src/services/users.js
@@ -1,0 +1,21 @@
+import api from './api'
+
+export function fetchUsers() {
+  return api.get('/api/auth/users')
+}
+
+export function createUser(payload) {
+  return api.post('/api/auth/users', payload)
+}
+
+export function fetchUser(id) {
+  return api.get(`/api/auth/users/${id}`)
+}
+
+export function updateUser(id, payload) {
+  return api.put(`/api/auth/users/${id}`, payload)
+}
+
+export function deleteUser(id) {
+  return api.delete(`/api/auth/users/${id}`)
+}

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -1,5 +1,6 @@
 import { createStore } from 'vuex'
-import { setToken, fetchCurrentUser as apiFetchCurrentUser } from '../services/api'
+import { setToken } from '../services/api'
+import { fetchCurrentUser as apiFetchCurrentUser } from '../services/auth'
 
 export default createStore({
   state: {

--- a/frontend/src/views/AdminUsers.vue
+++ b/frontend/src/views/AdminUsers.vue
@@ -116,7 +116,7 @@
 
 <script setup>
   import { ref, onMounted } from 'vue'
-  import { fetchUsers, updateUser, deleteUser, createUser } from '../services/api'
+  import { fetchUsers, updateUser, deleteUser, createUser } from '../services/users'
 
   const users = ref([])
   const editDialog = ref(false)

--- a/frontend/src/views/CancelamentoDuplicidade.vue
+++ b/frontend/src/views/CancelamentoDuplicidade.vue
@@ -90,7 +90,7 @@
 
 <script setup>
 import { ref, computed } from 'vue'
-import { pesquisarAutoInfracao } from '../services/api'
+import { pesquisarAutoInfracao } from '../services/autoprf'
 
 const numeroAi1 = ref('')
 const numeroAi2 = ref('')

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -86,7 +86,7 @@
 import { ref, onMounted, watch } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import { useStore } from 'vuex'
-import { loginUser } from '../services/api'
+import { loginUser } from '../services/auth'
 
 const email = ref('')
 const senha = ref('')

--- a/frontend/src/views/Register.vue
+++ b/frontend/src/views/Register.vue
@@ -101,7 +101,7 @@
 <script setup>
 import { ref } from 'vue'
 import { useRouter } from 'vue-router'
-import { registerUser } from '../services/api'
+import { registerUser } from '../services/auth'
 
 const username = ref('')
 const email = ref('')

--- a/frontend/src/views/VeiculosEmergencia.vue
+++ b/frontend/src/views/VeiculosEmergencia.vue
@@ -78,7 +78,7 @@
 
 <script setup>
 import { ref } from 'vue'
-import { pesquisarAutoInfracao, obterEnvolvidos } from '../services/api'
+import { pesquisarAutoInfracao, obterEnvolvidos } from '../services/autoprf'
 
 const numeroAi = ref('')
 const envolvidos = ref([])


### PR DESCRIPTION
## Summary
- split Vue services into separate modules for auth, users, and AutoPRF
- adjust imports across components, views and store

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685eaafb3b8c832eba50e6a89a36294d