### PR TITLE
Add SISCOM AI search

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,6 +1,6 @@
 from flask import Flask
 from .extensions import db, migrate, jwt, cors
-from .routes import auth, scraping, autoprf
+from .routes import auth, scraping, autoprf, siscom
 
 def create_app():
     app = Flask(__name__)
@@ -13,5 +13,6 @@ def create_app():
     app.register_blueprint(auth.bp)
     app.register_blueprint(scraping.bp)
     app.register_blueprint(autoprf.bp)
+    app.register_blueprint(siscom.bp)
 
     return app

--- a/backend/app/routes/siscom.py
+++ b/backend/app/routes/siscom.py
@@ -1,0 +1,34 @@
+import os
+import requests
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required
+
+ENDPOINT = os.getenv("SISCOM_ENDPOINT", "http://example.com/siscom")
+
+bp = Blueprint("siscom", __name__, url_prefix="/api/siscom")
+
+
+@bp.route("/pesquisar_ai", methods=["POST"])
+@jwt_required()
+def pesquisar_ai():
+    data = request.get_json() or {}
+    numero = data.get("numero") or data.get("auto_infracao")
+    if not numero:
+        return jsonify({"msg": "Número do AI não informado"}), 400
+
+    response = requests.get(f"{ENDPOINT}/{numero}")
+    response.raise_for_status()
+    payload = response.json() if response.content else {}
+
+    fields = [
+        "numeroAuto",
+        "codigoInfracao",
+        "descAbreviadaInfracao",
+        "placa",
+        "renavam",
+        "kmInfracao",
+        "municipioInfracao",
+        "valorInfracao",
+    ]
+    result = {field: payload.get(field) for field in fields}
+    return jsonify(result)

--- a/backend/tests/test_siscom.py
+++ b/backend/tests/test_siscom.py
@@ -1,0 +1,79 @@
+from app.extensions import db
+from app.models import User
+from app.routes.siscom import ENDPOINT
+import requests
+
+
+def create_user():
+    user = User(
+        username="testuser",
+        email="test@example.com",
+        administrador=False,
+        cpf="12345678909",
+    )
+    user.set_password("password")
+    db.session.add(user)
+    db.session.commit()
+    return user
+
+
+def get_token(client, email="test@example.com", password="password"):
+    response = client.post(
+        "/api/auth/login",
+        json={"email": email, "password": password},
+    )
+    assert response.status_code == 200
+    return response.get_json()["access_token"]
+
+
+def test_pesquisar_ai_returns_filtered_fields(client, app, monkeypatch):
+    with app.app_context():
+        create_user()
+
+    token = get_token(client)
+
+    payload = {
+        "numeroAuto": "A1",
+        "codigoInfracao": "123",
+        "descAbreviadaInfracao": "desc",
+        "placa": "ABC1234",
+        "renavam": "999",
+        "kmInfracao": "10",
+        "municipioInfracao": {"nome": "Cidade"},
+        "valorInfracao": 100.0,
+        "extra": "ignored",
+    }
+
+    class FakeResponse:
+        status_code = 200
+        content = b"data"
+
+        def json(self):
+            return payload
+
+        def raise_for_status(self):
+            pass
+
+    def fake_get(url):
+        assert url == f"{ENDPOINT}/123"
+        return FakeResponse()
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    response = client.post(
+        "/api/siscom/pesquisar_ai",
+        json={"numero": "123"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 200
+    assert response.get_json() == {
+        "numeroAuto": "A1",
+        "codigoInfracao": "123",
+        "descAbreviadaInfracao": "desc",
+        "placa": "ABC1234",
+        "renavam": "999",
+        "kmInfracao": "10",
+        "municipioInfracao": {"nome": "Cidade"},
+        "valorInfracao": 100.0,
+    }

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -63,6 +63,11 @@
           prepend-icon="mdi-lock"
           @click="siscomDialog = true"
         />
+        <v-list-item
+          title="Pesquisar AI"
+          prepend-icon="mdi-magnify"
+          @click="siscomPesquisaDialog = true"
+        />
       </v-list-group>
 
       <v-list-group value="sei">
@@ -110,6 +115,22 @@
             <v-spacer />
             <v-btn text @click="autoprfPesquisaDialog = false">Cancelar</v-btn>
             <v-btn color="primary" :disabled="!autoprfPesquisaValid" @click="pesquisarAI">Pesquisar</v-btn>
+          </v-card-actions>
+        </v-card>
+      </v-dialog>
+
+      <v-dialog v-model="siscomPesquisaDialog" max-width="400">
+        <v-card>
+          <v-card-title>Pesquisar Auto de Infração</v-card-title>
+          <v-card-text>
+            <v-form ref="siscomPesquisaForm" v-model="siscomPesquisaValid">
+              <v-text-field v-model="siscomNumeroAi" label="Número do AI" :rules="[rules.required]" />
+            </v-form>
+          </v-card-text>
+          <v-card-actions>
+            <v-spacer />
+            <v-btn text @click="siscomPesquisaDialog = false">Cancelar</v-btn>
+            <v-btn color="primary" :disabled="!siscomPesquisaValid" @click="pesquisarSiscomAi">Pesquisar</v-btn>
           </v-card-actions>
         </v-card>
       </v-dialog>
@@ -164,6 +185,7 @@ import { useStore } from 'vuex'
 import { useRouter } from 'vue-router'
 import { updateUser } from '../services/users'
 import { autoprfLogin, pesquisarAutoInfracao } from '../services/autoprf'
+import { pesquisarAi as pesquisarSiscom } from '../services/siscom'
 
 const props = defineProps({
   modelValue: {
@@ -183,6 +205,7 @@ const router = useRouter()
 
 const autoprfDialog = ref(false)
 const autoprfPesquisaDialog = ref(false)
+const siscomPesquisaDialog = ref(false)
 const siscomDialog = ref(false)
 const seiDialog = ref(false)
 
@@ -192,11 +215,14 @@ const siscomSenha = ref('')
 const seiSenha = ref('')
 const seiToken = ref('')
 const autoInfracao = ref('')
+const siscomNumeroAi = ref('')
 
 const autoprfForm = ref(null)
 const autoprfValid = ref(false)
 const autoprfPesquisaForm = ref(null)
 const autoprfPesquisaValid = ref(false)
+const siscomPesquisaForm = ref(null)
+const siscomPesquisaValid = ref(false)
 const siscomForm = ref(null)
 const siscomValid = ref(false)
 const seiForm = ref(null)
@@ -243,6 +269,24 @@ async function pesquisarAI() {
     autoprfPesquisaDialog.value = false
     autoInfracao.value = ''
     router.push('/resultado-ai')
+  } catch (err) {
+    snackbarMsg.value = err.response?.data?.msg || 'Erro ao pesquisar AI'
+    snackbarColor.value = 'error'
+    snackbar.value = true
+  }
+}
+
+async function pesquisarSiscomAi() {
+  if (!siscomPesquisaForm.value?.validate()) return
+  try {
+    const { data } = await pesquisarSiscom({ numero: siscomNumeroAi.value })
+    store.commit('setSiscomAiResult', data)
+    snackbarMsg.value = 'Pesquisa enviada com sucesso'
+    snackbarColor.value = 'success'
+    snackbar.value = true
+    siscomPesquisaDialog.value = false
+    siscomNumeroAi.value = ''
+    router.push('/resultado-ai-siscom')
   } catch (err) {
     snackbarMsg.value = err.response?.data?.msg || 'Erro ao pesquisar AI'
     snackbarColor.value = 'error'

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -4,6 +4,7 @@ import Register from '../views/Register.vue'
 import Home from '../views/Home.vue'
 import AdminUsers from '../views/AdminUsers.vue'
 import AutoInfracao from '../views/AutoInfracao.vue'
+import AutoInfracaoSiscom from '../views/AutoInfracaoSiscom.vue'
 import VeiculosEmergencia from '../views/VeiculosEmergencia.vue'
 import CancelamentoDuplicidade from '../views/CancelamentoDuplicidade.vue'
 import store from '../store'
@@ -25,6 +26,11 @@ const routes = [
     path: '/resultado-ai',
     component: AutoInfracao,
     meta: { requiresAuth: true, title: 'Pesquisa do Auto de Infração' }
+  },
+  {
+    path: '/resultado-ai-siscom',
+    component: AutoInfracaoSiscom,
+    meta: { requiresAuth: true, title: 'Pesquisa AI SISCOM' }
   },
   {
     path: '/cancelamentos/veiculos-emergencia',

--- a/frontend/src/services/siscom.js
+++ b/frontend/src/services/siscom.js
@@ -1,0 +1,5 @@
+import api from './api'
+
+export function pesquisarAi(payload) {
+  return api.post('/api/siscom/pesquisar_ai', payload)
+}

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -7,6 +7,7 @@ export default createStore({
     user: null,
     token: localStorage.getItem('token') || null,
     aiResult: null,
+    siscomAiResult: null,
     loading: false,
     snackbar: { show: false, msg: '', color: 'success' }
   },
@@ -25,6 +26,9 @@ export default createStore({
     },
     setAiResult(state, data) {
       state.aiResult = data
+    },
+    setSiscomAiResult(state, data) {
+      state.siscomAiResult = data
     },
     setLoading(state, value) {
       state.loading = value

--- a/frontend/src/views/AutoInfracaoSiscom.vue
+++ b/frontend/src/views/AutoInfracaoSiscom.vue
@@ -1,0 +1,67 @@
+<template>
+  <v-container>
+    <v-row>
+      <v-col cols="12">
+        <v-card class="pa-4" elevation="2">
+          <h2>Auto de Infração SISCOM</h2>
+        </v-card>
+      </v-col>
+    </v-row>
+    <v-row class="my-2">
+      <v-col cols="12" class="text-right">
+        <v-btn color="primary" @click="limparConsulta">Limpar</v-btn>
+      </v-col>
+    </v-row>
+
+    <v-card class="pa-4 mb-4" elevation="2">
+      <v-row dense>
+        <v-col cols="12" md="3">
+          <v-text-field :model-value="ai?.numeroAuto" label="Número AI" readonly />
+        </v-col>
+        <v-col cols="12" md="3">
+          <v-text-field :model-value="ai?.codigoInfracao" label="Código" readonly />
+        </v-col>
+        <v-col cols="12" md="6">
+          <v-text-field :model-value="ai?.descAbreviadaInfracao" label="Descrição" readonly />
+        </v-col>
+        <v-col cols="12" md="3">
+          <v-text-field :model-value="ai?.placa" label="Placa" readonly />
+        </v-col>
+        <v-col cols="12" md="3">
+          <v-text-field :model-value="ai?.renavam" label="Renavam" readonly />
+        </v-col>
+        <v-col cols="12" md="3">
+          <v-text-field :model-value="ai?.kmInfracao" label="Km" readonly />
+        </v-col>
+        <v-col cols="12" md="3">
+          <v-text-field :model-value="ai?.municipioInfracao?.nome" label="Município" readonly />
+        </v-col>
+        <v-col cols="12" md="3">
+          <v-text-field :model-value="ai?.valorInfracao" label="Valor" readonly />
+        </v-col>
+      </v-row>
+    </v-card>
+  </v-container>
+</template>
+
+<script setup>
+import { computed, onMounted } from 'vue'
+import { useStore } from 'vuex'
+import { useRouter } from 'vue-router'
+
+const store = useStore()
+const router = useRouter()
+
+const ai = computed(() => store.state.siscomAiResult)
+
+onMounted(() => {
+  if (!ai.value) {
+    router.push('/')
+  }
+})
+
+function limparConsulta() {
+  store.commit('setSiscomAiResult', null)
+  router.push('/')
+}
+</script>


### PR DESCRIPTION
## Summary
- implement SISCOM AI search endpoint and blueprint
- register new blueprint in Flask app
- add Siscom service to frontend
- store Siscom AI results in Vuex
- create AutoInfracaoSiscom view and router entry
- allow sidebar to search AI via SISCOM
- add tests for the new backend route

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860ad29c04c832e8584cffd60e4ad64