### PR TITLE
Expand SISCOM data handling

### DIFF
--- a/backend/app/services/siscom_client.py
+++ b/backend/app/services/siscom_client.py
@@ -9,19 +9,82 @@ class SiscomClient:
         self.endpoint = endpoint or os.getenv("SISCOM_ENDPOINT")
 
     def pesquisar_ai(self, numero: str) -> dict:
-        """Search for an Auto de Infracao and return filtered fields."""
+        """Search for an Auto de Infracao and return a structured result."""
         response = requests.get(f"{self.endpoint}/{numero}")
         response.raise_for_status()
         payload = response.json() if response.content else {}
 
-        fields = [
-            "numeroAuto",
-            "codigoInfracao",
-            "descAbreviadaInfracao",
-            "placa",
-            "renavam",
-            "kmInfracao",
-            "municipioInfracao",
-            "valorInfracao",
-        ]
-        return {field: payload.get(field) for field in fields}
+        if not payload:
+            return {}
+
+        result: dict[str, dict | None] = {
+            "infracao": {},
+            "veiculo": {},
+            "local": {},
+            "medicoes": None,
+            "equipamento": None,
+            "observacoes": payload.get("observacoes"),
+        }
+
+        codigo = payload.get("codigoInfracao")
+        desc = payload.get("descAbreviadaInfracao")
+        if codigo or desc:
+            result["infracao"]["codigo_descricao"] = (
+                f"{codigo} - {desc}" if codigo and desc else codigo or desc
+            )
+        result["infracao"]["amparo_legal"] = payload.get("enquadramentoInfracao")
+        if payload.get("gravidadeInfracao"):
+            result["infracao"]["gravidade"] = payload.get("gravidadeInfracao")
+        if payload.get("tipoInfrator"):
+            result["infracao"]["tipo_infrator"] = payload.get("tipoInfrator")
+        if payload.get("tipoAbordagem"):
+            result["infracao"]["tipo_abordagem"] = payload.get("tipoAbordagem")
+
+        estrang = payload.get("veiculoEstrangeiro")
+        if estrang is not None:
+            result["veiculo"]["emplacamento"] = (
+                "Estrangeiro" if str(estrang).lower() == "true" else "Nacional"
+            )
+        result["veiculo"]["placa"] = payload.get("placa")
+        result["veiculo"]["chassi"] = payload.get("chassi")
+        result["veiculo"]["renavam"] = payload.get("renavam")
+        result["veiculo"]["pais"] = payload.get("pais")
+        result["veiculo"]["uf"] = payload.get("ufPlaca")
+        result["veiculo"]["marca"] = payload.get("marca")
+        result["veiculo"]["outra_marca"] = payload.get("outraMarca")
+        result["veiculo"]["modelo"] = payload.get("modelo")
+        result["veiculo"]["cor"] = payload.get("cor")
+        result["veiculo"]["especie"] = payload.get("descEspecie")
+        result["veiculo"]["tipo"] = payload.get("tipo")
+        result["veiculo"]["categoria"] = payload.get("categoria")
+        result["veiculo"]["tipo_documento"] = payload.get("tipoDocumento")
+        result["veiculo"]["numero_documento"] = payload.get("numeroDocumento")
+        proprietario = payload.get("nomeCondutor") or payload.get("nomProprietario")
+        if proprietario:
+            result["veiculo"]["nome_razao_social"] = proprietario
+        result["veiculo"]["tipo_composicao"] = payload.get("tipoComposicao")
+
+        municipio = payload.get("municipioInfracao") or {}
+        cod = municipio.get("codMunicipio")
+        nome = municipio.get("nome")
+        uf = municipio.get("UF")
+        if cod or nome or uf:
+            parts = []
+            if cod:
+                parts.append(str(cod))
+            if nome or uf:
+                nomeuf = f"{nome}/{uf}" if nome or uf else ""
+                if cod:
+                    parts.append(nomeuf)
+                else:
+                    parts = [nomeuf]
+            result["local"]["codigo_municipio_uf"] = " - ".join(parts)
+        result["local"]["rodovia"] = payload.get("brInfracao")
+        if payload.get("kmInfracao") is not None:
+            result["local"]["km"] = str(payload.get("kmInfracao"))
+        result["local"]["sentido"] = payload.get("sentidoVia")
+        data_hora = payload.get("dataHoraInfracao")
+        if data_hora:
+            result["local"]["data_hora"] = data_hora
+
+        return result

--- a/frontend/src/views/AutoInfracaoSiscom.vue
+++ b/frontend/src/views/AutoInfracaoSiscom.vue
@@ -214,52 +214,10 @@ import { useRouter } from 'vue-router'
 const store = useStore()
 const router = useRouter()
 
-const rawAi = computed(() => store.state.siscomAiResult)
-const ai = computed(() => {
-  const data = rawAi.value
-  if (!data) return null
-  return {
-    infracao: {
-      codigo_descricao: data.codigoInfracao ? `${data.codigoInfracao} - ${data.descAbreviadaInfracao}` : null,
-      amparo_legal: data.enquadramentoInfracao,
-      gravidade: data.gravidadeInfracao,
-      tipo_infrator: data.tipoInfrator,
-      tipo_abordagem: data.tipoAbordagem,
-    },
-    veiculo: {
-      emplacamento: data.veiculoEstrangeiro === 'true' ? 'Estrangeiro' : 'Nacional',
-      placa: data.placa,
-      chassi: data.chassi,
-      renavam: data.renavam,
-      pais: data.pais,
-      uf: data.ufPlaca,
-      marca: data.marca,
-      outra_marca: data.outraMarca,
-      modelo: data.modelo,
-      cor: data.cor,
-      especie: data.descEspecie,
-      tipo: data.tipo,
-      categoria: data.categoria,
-      tipo_documento: data.tipoDocumento,
-      numero_documento: data.numeroDocumento,
-      nome_razao_social: data.nomeCondutor || data.nomProprietario,
-      tipo_composicao: data.tipoComposicao,
-    },
-    local: {
-      codigo_municipio_uf: data.municipioInfracao ? `${data.municipioInfracao.codMunicipio} - ${data.municipioInfracao.nome}/${data.municipioInfracao.UF}` : null,
-      rodovia: data.brInfracao,
-      km: data.kmInfracao,
-      sentido: data.sentidoVia,
-      data_hora: data.dataHoraInfracao ? new Date(data.dataHoraInfracao).toLocaleString() : null,
-    },
-    medicoes: null,
-    equipamento: null,
-    observacoes: data.observacoes,
-  }
-})
+const ai = computed(() => store.state.siscomAiResult)
 
 onMounted(() => {
-  if (!rawAi.value) {
+  if (!ai.value) {
     router.push('/')
   }
 })


### PR DESCRIPTION
## Summary
- return structured result from `SiscomClient.pesquisar_ai`
- expose all returned data in `siscom` route
- expect structured payload in tests
- simplify SISCOM view to use stored result directly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860ba817a78832e9562692d69630b2a