### PR TITLE
Add SISCOM histórico endpoint and frontend view

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,7 @@ When the backend detects that an AutoPRF request failed with status `401` or
 message `Sessão AutoPRF expirada`. The frontend intercepts this response,
 logs the user out and shows a snackbar saying `Sessão expirada` before
 redirecting to the home page.
+
+## SISCOM
+
+- `POST /api/siscom/historico` – retorna o histórico do Auto de Infração.

--- a/backend/app/routes/siscom.py
+++ b/backend/app/routes/siscom.py
@@ -18,5 +18,18 @@ def pesquisar_ai():
         return jsonify({"msg": "Número do AI não informado"}), 400
 
     client = SiscomClient(endpoint=ENDPOINT)
-    result = client.pesquisar_ai(numero)   
+    result = client.pesquisar_ai(numero)
+    return jsonify(result)
+
+
+@bp.route("/historico", methods=["POST"])
+@jwt_required()
+def historico():
+    data = request.get_json() or {}
+    numero = data.get("numero")
+    if not numero:
+        return jsonify({"msg": "Número do AI não informado"}), 400
+
+    client = SiscomClient(endpoint=ENDPOINT)
+    result = client.historico(numero)
     return jsonify(result)

--- a/backend/app/services/siscom_client.py
+++ b/backend/app/services/siscom_client.py
@@ -88,3 +88,12 @@ class SiscomClient:
             result["local"]["data_hora"] = data_hora
 
         return result
+
+    def historico(self, numero: str) -> list:
+        """Return the historical status list for an Auto de Infracao."""
+        url = (
+            f"{self.endpoint}/historico?numeroAuto%7D=&find=ByNumeroAutoEquals&numeroAuto={numero}"
+        )
+        response = requests.get(url)
+        response.raise_for_status()
+        return response.json() if response.content else []

--- a/backend/tests/test_siscom.py
+++ b/backend/tests/test_siscom.py
@@ -60,3 +60,32 @@ def test_pesquisar_ai_returns_structured_data(client, app, monkeypatch):
 
     assert response.status_code == 200
     assert response.get_json() == expected
+
+
+def test_historico_returns_list(client, app, monkeypatch):
+    with app.app_context():
+        create_user()
+
+    token = get_token(client)
+
+    expected = [{"dataHistorico": 1, "status": "foo"}]
+
+    def fake_init(self, endpoint=None):
+        assert endpoint == ENDPOINT
+        self.endpoint = endpoint
+
+    def fake_historico(self, numero):
+        assert numero == "321"
+        return expected
+
+    monkeypatch.setattr(SiscomClient, "__init__", fake_init)
+    monkeypatch.setattr(SiscomClient, "historico", fake_historico)
+
+    response = client.post(
+        "/api/siscom/historico",
+        json={"numero": "321"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 200
+    assert response.get_json() == expected

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -68,6 +68,11 @@
           prepend-icon="mdi-magnify"
           @click="siscomPesquisaDialog = true"
         />
+        <v-list-item
+          title="Histórico"
+          prepend-icon="mdi-history"
+          to="/historico-siscom"
+        />
       </v-list-group>
 
       <v-list-group value="sei">

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -5,6 +5,7 @@ import Home from '../views/Home.vue'
 import AdminUsers from '../views/AdminUsers.vue'
 import AutoInfracao from '../views/AutoInfracao.vue'
 import AutoInfracaoSiscom from '../views/AutoInfracaoSiscom.vue'
+import HistoricoSiscom from '../views/HistoricoSiscom.vue'
 import VeiculosEmergencia from '../views/VeiculosEmergencia.vue'
 import CancelamentoDuplicidade from '../views/CancelamentoDuplicidade.vue'
 import store from '../store'
@@ -31,6 +32,11 @@ const routes = [
     path: '/resultado-ai-siscom',
     component: AutoInfracaoSiscom,
     meta: { requiresAuth: true, title: 'Pesquisa AI SISCOM' }
+  },
+  {
+    path: '/historico-siscom',
+    component: HistoricoSiscom,
+    meta: { requiresAuth: true, title: 'Histórico do Auto de Infração' }
   },
   {
     path: '/cancelamentos/veiculos-emergencia',

--- a/frontend/src/services/siscom.js
+++ b/frontend/src/services/siscom.js
@@ -3,3 +3,7 @@ import api from './api'
 export function pesquisarAi(payload) {
   return api.post('/api/siscom/pesquisar_ai', payload)
 }
+
+export function buscarHistorico(payload) {
+  return api.post('/api/siscom/historico', payload)
+}

--- a/frontend/src/views/HistoricoSiscom.vue
+++ b/frontend/src/views/HistoricoSiscom.vue
@@ -1,0 +1,71 @@
+<template>
+  <v-container>
+    <v-row>
+      <v-col cols="12" md="4">
+        <v-card class="pa-4 mb-4" elevation="2" title="Histórico do AI">
+          <v-form ref="formRef" v-model="valid">
+            <v-text-field
+              v-model="numeroAi"
+              label="Número do Auto de Infração"
+              :rules="[rules.required]"
+            />
+            <v-btn color="primary" class="mt-2" @click="buscar" :disabled="!valid">
+              Pesquisar
+            </v-btn>
+            <v-btn color="secondary" class="mt-2 ml-2" @click="limpar">
+              Limpar
+            </v-btn>
+          </v-form>
+        </v-card>
+      </v-col>
+    </v-row>
+
+    <v-card v-if="historico.length" class="pa-4" elevation="2">
+      <v-card-title>Histórico</v-card-title>
+      <v-data-table :headers="headers" :items="historico" item-key="dataHistorico">
+        <template #item.dataHistorico="{ item }">
+          {{ formatDate(item.dataHistorico) }}
+        </template>
+      </v-data-table>
+    </v-card>
+  </v-container>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { buscarHistorico } from '../services/siscom'
+
+const numeroAi = ref('')
+const historico = ref([])
+const formRef = ref(null)
+const valid = ref(false)
+
+const headers = [
+  { title: 'Data', key: 'dataHistorico' },
+  { title: 'Status', key: 'status' }
+]
+
+const rules = { required: v => !!v || 'Campo obrigatório' }
+
+async function buscar() {
+  if (!formRef.value?.validate()) return
+  try {
+    const { data } = await buscarHistorico({ numero: numeroAi.value })
+    historico.value = data
+  } catch (err) {
+    console.error(err)
+    historico.value = []
+  }
+}
+
+function limpar() {
+  numeroAi.value = ''
+  historico.value = []
+  formRef.value?.resetValidation()
+}
+
+function formatDate(ms) {
+  const d = new Date(Number(ms))
+  return isNaN(d) ? '' : d.toLocaleString()
+}
+</script>


### PR DESCRIPTION
## Summary
- add `SiscomClient.historico` for history lookup
- expose `/api/siscom/historico` POST route
- test new route with mocked client
- support buscarHistorico in frontend service
- add HistoricoSiscom view and navigation
- document route in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686533a72fc8832e8cd3b5c01d31d022