### PR TITLE
Implement Veiculo consulta

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,6 +1,6 @@
 from flask import Flask
 from .extensions import db, migrate, jwt, cors
-from .routes import auth, scraping, autoprf, siscom
+from .routes import auth, scraping, autoprf, siscom, veiculo
 
 def create_app():
     app = Flask(__name__)
@@ -14,5 +14,6 @@ def create_app():
     app.register_blueprint(scraping.bp)
     app.register_blueprint(autoprf.bp)
     app.register_blueprint(siscom.bp)
+    app.register_blueprint(veiculo.bp)
 
     return app

--- a/backend/app/routes/veiculo.py
+++ b/backend/app/routes/veiculo.py
@@ -1,0 +1,19 @@
+from flask import Blueprint, request, jsonify
+from flask_jwt_extended import jwt_required
+
+from ..services.veiculo_client import VeiculoClient
+
+bp = Blueprint("veiculo", __name__, url_prefix="/api/veiculo")
+
+
+@bp.route("/placa", methods=["POST"])
+@jwt_required()
+def consultar_por_placa():
+    data = request.get_json() or {}
+    placa = data.get("placa")
+    if not placa:
+        return jsonify({"msg": "Placa não informada"}), 400
+
+    client = VeiculoClient()
+    result = client.consultar_placa(placa)
+    return jsonify(result)

--- a/backend/app/services/veiculo_client.py
+++ b/backend/app/services/veiculo_client.py
@@ -1,0 +1,16 @@
+import requests
+
+class VeiculoClient:
+    """Client to consult vehicle data by plate."""
+
+    BASE_URL = (
+        "http://10.0.11.220:8080/MotorConsultas/consulta?matricula=1535421&cpf="
+        "68109911234&objeto=VEICULO&campo=PLACA&sistema=22&chave={placa}"
+    )
+
+    def consultar_placa(self, placa: str) -> dict:
+        """Query the vehicle service for the provided plate."""
+        url = self.BASE_URL.format(placa=placa)
+        response = requests.get(url)
+        response.raise_for_status()
+        return response.json()

--- a/backend/tests/test_veiculo.py
+++ b/backend/tests/test_veiculo.py
@@ -1,0 +1,62 @@
+from app.extensions import db
+from app.models import User
+from app.services.veiculo_client import VeiculoClient
+
+
+def create_user():
+    user = User(
+        username="testuser",
+        email="test@example.com",
+        administrador=False,
+        cpf="12345678909",
+    )
+    user.set_password("password")
+    db.session.add(user)
+    db.session.commit()
+    return user
+
+
+def get_token(client, email="test@example.com", password="password"):
+    response = client.post(
+        "/api/auth/login",
+        json={"email": email, "password": password},
+    )
+    assert response.status_code == 200
+    return response.get_json()["access_token"]
+
+
+def test_consultar_placa_returns_data(client, app, monkeypatch):
+    with app.app_context():
+        create_user()
+
+    token = get_token(client)
+
+    expected = {"placa": "ABC1234", "marca": "TEST"}
+
+    def fake_consultar(self, placa):
+        assert placa == "ABC1234"
+        return expected
+
+    monkeypatch.setattr(VeiculoClient, "consultar_placa", fake_consultar)
+
+    response = client.post(
+        "/api/veiculo/placa",
+        json={"placa": "ABC1234"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 200
+    assert response.get_json() == expected
+
+
+def test_consultar_placa_requires_jwt(client, app, monkeypatch):
+    with app.app_context():
+        create_user()
+
+    # No token provided
+    response = client.post(
+        "/api/veiculo/placa",
+        json={"placa": "XYZ9999"},
+    )
+
+    assert response.status_code == 401


### PR DESCRIPTION
## Summary
- add veiculo client service
- expose /api/veiculo/placa endpoint
- register new blueprint
- test vehicle lookup and JWT protection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865408530d8832e8c3fe1cd9fe2d8d8