### PR TITLE
Add veiculo service and store support

### DIFF
--- a/frontend/src/services/veiculo.js
+++ b/frontend/src/services/veiculo.js
@@ -1,0 +1,5 @@
+import api from './api'
+
+export function consultarPlaca(payload) {
+  return api.post('/api/veiculo/placa', payload)
+}

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -1,6 +1,7 @@
 import { createStore } from 'vuex'
 import { setToken } from '../services/api'
 import { fetchCurrentUser as apiFetchCurrentUser } from '../services/auth'
+import { consultarPlaca as apiConsultarPlaca } from '../services/veiculo'
 
 export default createStore({
   state: {
@@ -8,6 +9,7 @@ export default createStore({
     token: localStorage.getItem('token') || null,
     aiResult: null,
     siscomAiResult: null,
+    veiculoResult: null,
     loading: false,
     snackbar: { show: false, msg: '', color: 'success' }
   },
@@ -30,6 +32,9 @@ export default createStore({
     setSiscomAiResult(state, data) {
       state.siscomAiResult = data
     },
+    setVeiculoResult(state, data) {
+      state.veiculoResult = data
+    },
     setLoading(state, value) {
       state.loading = value
     },
@@ -44,6 +49,7 @@ export default createStore({
     logout(state) {
       state.user = null
       state.token = null
+      state.veiculoResult = null
       setToken(null)
       localStorage.removeItem('token')
     }
@@ -67,6 +73,10 @@ export default createStore({
       } catch (e) {
         commit('logout')
       }
+    },
+    async consultarPlaca({ commit }, payload) {
+      const { data } = await apiConsultarPlaca(payload)
+      commit('setVeiculoResult', data)
     }
   },
   modules: {}


### PR DESCRIPTION
## Summary
- add `consultarPlaca` service to post `/api/veiculo/placa`
- track vehicle lookup result in the store
- expose `consultarPlaca` action and clear result on logout

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68654d8e58e4832e8c1e20af066ee013