### PR TITLE
Add vehicle lookup view and menu

### DIFF
--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -68,14 +68,20 @@
           prepend-icon="mdi-magnify"
           to="/resultado-ai-siscom"
         />
-        <v-list-item
-          title="Histórico"
-          prepend-icon="mdi-history"
-          to="/historico-siscom"
-        />
-      </v-list-group>
+      <v-list-item
+        title="Histórico"
+        prepend-icon="mdi-history"
+        to="/historico-siscom"
+      />
+    </v-list-group>
 
-      <v-list-group value="sei">
+    <v-list-item
+      title="Veículo"
+      prepend-icon="mdi-car-search"
+      to="/veiculo"
+    />
+
+    <v-list-group value="sei">
         <template #activator="{ props }">
           <v-list-item
             v-bind="props"

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -8,6 +8,7 @@ import AutoInfracaoSiscom from '../views/AutoInfracaoSiscom.vue'
 import HistoricoSiscom from '../views/HistoricoSiscom.vue'
 import VeiculosEmergencia from '../views/VeiculosEmergencia.vue'
 import CancelamentoDuplicidade from '../views/CancelamentoDuplicidade.vue'
+import Veiculo from '../views/Veiculo.vue'
 import store from '../store'
 
 const routes = [
@@ -37,6 +38,11 @@ const routes = [
     path: '/historico-siscom',
     component: HistoricoSiscom,
     meta: { requiresAuth: true, title: 'Histórico do Auto de Infração' }
+  },
+  {
+    path: '/veiculo',
+    component: Veiculo,
+    meta: { requiresAuth: true, title: 'Consulta de Veículo' }
   },
   {
     path: '/cancelamentos/veiculos-emergencia',

--- a/frontend/src/services/veiculo.js
+++ b/frontend/src/services/veiculo.js
@@ -1,0 +1,5 @@
+import api from './api'
+
+export function consultarPlaca(payload) {
+  return api.post('/api/veiculo/placa', payload)
+}

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -1,6 +1,7 @@
 import { createStore } from 'vuex'
 import { setToken } from '../services/api'
 import { fetchCurrentUser as apiFetchCurrentUser } from '../services/auth'
+import { consultarPlaca as apiConsultarPlaca } from '../services/veiculo'
 
 export default createStore({
   state: {
@@ -8,6 +9,7 @@ export default createStore({
     token: localStorage.getItem('token') || null,
     aiResult: null,
     siscomAiResult: null,
+    veiculoResult: null,
     loading: false,
     snackbar: { show: false, msg: '', color: 'success' }
   },
@@ -30,6 +32,9 @@ export default createStore({
     setSiscomAiResult(state, data) {
       state.siscomAiResult = data
     },
+    setVeiculoResult(state, data) {
+      state.veiculoResult = data
+    },
     setLoading(state, value) {
       state.loading = value
     },
@@ -44,6 +49,7 @@ export default createStore({
     logout(state) {
       state.user = null
       state.token = null
+      state.veiculoResult = null
       setToken(null)
       localStorage.removeItem('token')
     }
@@ -67,6 +73,10 @@ export default createStore({
       } catch (e) {
         commit('logout')
       }
+    },
+    async consultarPlaca({ commit }, payload) {
+      const { data } = await apiConsultarPlaca(payload)
+      commit('setVeiculoResult', data)
     }
   },
   modules: {}

--- a/frontend/src/views/Veiculo.vue
+++ b/frontend/src/views/Veiculo.vue
@@ -1,0 +1,64 @@
+<template>
+  <v-container>
+    <v-row>
+      <v-col cols="12" md="4">
+        <v-card class="pa-4 mb-4" elevation="2" title="Consulta de Veículo">
+          <v-form ref="formRef" v-model="valid">
+            <v-text-field
+              v-model="placa"
+              label="Placa"
+              :rules="[rules.required]"
+            />
+            <v-btn color="primary" class="mt-2" @click="buscar" :disabled="!valid">
+              Pesquisar
+            </v-btn>
+            <v-btn color="secondary" class="mt-2 ml-2" @click="limpar">
+              Limpar
+            </v-btn>
+          </v-form>
+        </v-card>
+      </v-col>
+    </v-row>
+
+    <v-card v-if="result" class="pa-4" elevation="2">
+      <v-card-title>Resultado</v-card-title>
+      <v-card-text>
+        <pre>{{ result }}</pre>
+      </v-card-text>
+    </v-card>
+  </v-container>
+</template>
+
+<script setup>
+import { ref, computed } from 'vue'
+import { useStore } from 'vuex'
+
+const store = useStore()
+
+const placa = ref('')
+const formRef = ref(null)
+const valid = ref(false)
+
+const result = computed(() => store.state.veiculoResult)
+
+const rules = { required: v => !!v || 'Campo obrigatório' }
+
+async function buscar() {
+  if (!formRef.value?.validate()) return
+  try {
+    await store.dispatch('consultarPlaca', { placa: placa.value })
+  } catch (err) {
+    store.commit('showSnackbar', {
+      msg: err.response?.data?.msg || 'Erro ao consultar placa'
+    })
+    store.commit('setVeiculoResult', null)
+  }
+}
+
+function limpar() {
+  placa.value = ''
+  store.commit('setVeiculoResult', null)
+  formRef.value?.resetValidation()
+}
+</script>
+


### PR DESCRIPTION
## Summary
- create `Veiculo.vue` for searching plates
- register new page in router
- link to the new page from the sidebar

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68654d8e58e4832e8c1e20af066ee013