### PR TITLE
Improve vehicle results layout

### DIFF
--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -77,7 +77,7 @@
 
     <v-list-item
       title="Veículo"
-      prepend-icon="mdi-car-search"
+      prepend-icon="mdi-car"
       to="/veiculo"
     />
 

--- a/frontend/src/views/Veiculo.vue
+++ b/frontend/src/views/Veiculo.vue
@@ -20,12 +20,135 @@
       </v-col>
     </v-row>
 
-    <v-card v-if="result" class="pa-4" elevation="2">
-      <v-card-title>Resultado</v-card-title>
-      <v-card-text>
-        <pre>{{ result }}</pre>
-      </v-card-text>
-    </v-card>
+    <template v-if="result">
+      <v-card class="pa-4 mb-4" elevation="2">
+        <h3 class="pa-4">Dados do Veículo</h3>
+        <v-row dense>
+          <v-col cols="12" md="4">
+            <v-text-field
+              :model-value="result.ano_fabricacao"
+              label="Ano de Fabricação"
+              readonly
+            />
+          </v-col>
+          <v-col cols="12" md="4">
+            <v-text-field
+              :model-value="result.ano_modelo"
+              label="Ano do Modelo"
+              readonly
+            />
+          </v-col>
+          <v-col cols="12" md="4">
+            <v-text-field
+              :model-value="result.ano_ultimo_licenciamento"
+              label="Ano do Último Licenciamento"
+              readonly
+            />
+          </v-col>
+          <v-col cols="12" md="4">
+            <v-text-field
+              :model-value="result.capacidade_carga"
+              label="Capacidade de Carga"
+              readonly
+            />
+          </v-col>
+          <v-col cols="12" md="4">
+            <v-text-field
+              :model-value="result.cmt"
+              label="Capacitada Máxima de Tração (CMT)"
+              readonly
+            />
+          </v-col>
+          <v-col cols="12" md="4">
+            <v-text-field
+              :model-value="result.capacidade_maxima_passageiros"
+              label="Capacidade Máxima de Passageiros"
+              readonly
+            />
+          </v-col>
+          <v-col cols="12" md="4">
+            <v-text-field :model-value="result.categoria" label="Categoria" readonly />
+          </v-col>
+          <v-col cols="12" md="6">
+            <v-text-field :model-value="result.chassi" label="Chassi" readonly />
+          </v-col>
+          <v-col cols="12" md="4">
+            <v-text-field :model-value="result.cilindradas" label="Cilindradas" readonly />
+          </v-col>
+          <v-col cols="12" md="4">
+            <v-text-field :model-value="result.cor" label="Cor" readonly />
+          </v-col>
+          <v-col cols="12" md="6">
+            <v-text-field :model-value="result.combustivel" label="Combustível" readonly />
+          </v-col>
+          <v-col cols="12" md="4">
+            <v-text-field
+              :model-value="result.tipo_documento_proprietario"
+              label="Tipo do Documento do Proprietário"
+              readonly
+            />
+          </v-col>
+          <v-col cols="12" md="6">
+            <v-text-field
+              :model-value="result.documento_proprietario"
+              label="Documento do Proprietário"
+              readonly
+            />
+          </v-col>
+          <v-col cols="12" md="6">
+            <v-text-field :model-value="result.marca_modelo" label="Marca/Modelo" readonly />
+          </v-col>
+          <v-col cols="12" md="6">
+            <v-text-field
+              :model-value="result.municipio_emplacamento"
+              label="Município de Emplacamento"
+              readonly
+            />
+          </v-col>
+          <v-col cols="12" md="6">
+            <v-text-field :model-value="result.proprietario" label="Proprietário(a)" readonly />
+          </v-col>
+          <v-col cols="12" md="4">
+            <v-text-field :model-value="result.pais" label="País" readonly />
+          </v-col>
+          <v-col cols="12" md="4">
+            <v-text-field :model-value="result.pbt" label="Peso Bruto Total (PBT)" readonly />
+          </v-col>
+          <v-col cols="12" md="4">
+            <v-text-field :model-value="result.placa" label="Placa" readonly />
+          </v-col>
+          <v-col cols="12" md="4">
+            <v-text-field :model-value="result.procedencia" label="Procedência" readonly />
+          </v-col>
+          <v-col cols="12" md="4">
+            <v-text-field
+              :model-value="result.quantidade_multas"
+              label="Quantidade de Multas"
+              readonly
+            />
+          </v-col>
+          <v-col cols="12" md="4">
+            <v-text-field :model-value="result.renavam" label="Renavam" readonly />
+          </v-col>
+          <v-col cols="12" md="6">
+            <v-text-field :model-value="result.restricao" label="Restrição" readonly />
+          </v-col>
+          <v-col cols="12" md="6">
+            <v-text-field :model-value="result.situacao_veiculo" label="Situação do Veículo" readonly />
+          </v-col>
+          <v-col cols="12" md="6">
+            <v-text-field :model-value="result.tipo" label="Tipo" readonly />
+          </v-col>
+          <v-col cols="12" md="4">
+            <v-text-field
+              :model-value="result.uf_emplacamento"
+              label="UF de Emplacamento"
+              readonly
+            />
+          </v-col>
+        </v-row>
+      </v-card>
+    </template>
   </v-container>
 </template>
 


### PR DESCRIPTION
## Summary
- refine vehicle search UI
- present vehicle results in fixed layout
- move car icon to sidebar menu

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68655217c184832e87df2275a0c147d4