### PR TITLE
Implement cancelamento solicitacao

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,12 @@ redirecting to the home page.
 ## SISCOM
 
 - `POST /api/siscom/historico` – retorna o histórico do Auto de Infração.
+
+## AutoPRF
+
+- `POST /api/autoprf/solicitacao/cancelamento` – envia uma solicitação de
+  cancelamento de Auto de Infração utilizando a sessão autenticada.
+
+O frontend inclui um botão **Solicitação de Cancelamento** na tela de
+Veículos de Emergência que envia a requisição e exibe uma snackbar de sucesso
+quando a API responde `1` ou `true`.

--- a/backend/app/services/autoprf_client.py
+++ b/backend/app/services/autoprf_client.py
@@ -183,3 +183,25 @@ class AutoPRFClient:
         )
         response.raise_for_status()
         return response.json() if response.content else []
+
+    def solicitar_cancelamento(self, numero_auto: str, payload: dict) -> dict:
+        """Submit a cancelamento request for a given Auto de Infracao."""
+        headers = {}
+        if self.jwt_token:
+            headers["Authorization"] = f"Bearer {self.jwt_token}"
+
+        # Access the auto page so the service can locate the process
+        resp = requests.get(
+            f"{self.BASE_URL}/auto-infracao/page",
+            params={"numero": numero_auto},
+            headers=headers,
+        )
+        resp.raise_for_status()
+
+        resp = requests.post(
+            f"{self.BASE_URL}/solicitacao/CANCELAMENTO/lote",
+            json=payload,
+            headers=headers,
+        )
+        resp.raise_for_status()
+        return resp.json() if resp.content else {}

--- a/frontend/src/services/autoprf.js
+++ b/frontend/src/services/autoprf.js
@@ -11,3 +11,7 @@ export function pesquisarAutoInfracao(payload) {
 export function obterEnvolvidos(id) {
   return api.get(`/api/autoprf/envolvidos/${id}`)
 }
+
+export function solicitarCancelamento(payload) {
+  return api.post('/api/autoprf/solicitacao/cancelamento', payload)
+}


### PR DESCRIPTION
## Summary
- add solicitar_cancelamento method in AutoPRFClient
- expose /api/autoprf/solicitacao/cancelamento endpoint
- wire frontend service and button for sending cancelamento
- extend unit tests for new backend route
- document the new API endpoint and frontend feature

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686580b53d48832e87e7cb3311b928d9