### PR TITLE
Implement SEI login

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,6 +1,6 @@
 from flask import Flask
 from .extensions import db, migrate, jwt, cors
-from .routes import auth, scraping, autoprf, siscom, veiculo
+from .routes import auth, scraping, autoprf, siscom, veiculo, sei
 
 def create_app():
     app = Flask(__name__)
@@ -15,5 +15,6 @@ def create_app():
     app.register_blueprint(autoprf.bp)
     app.register_blueprint(siscom.bp)
     app.register_blueprint(veiculo.bp)
+    app.register_blueprint(sei.bp)
 
     return app

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -14,6 +14,7 @@ class User(db.Model):
     senha_siscom_hash = db.Column('senha_siscom', db.String(120))
     senha_sei_hash = db.Column('senha_sei', db.String(120))
     token_sei = db.Column(db.String(120))
+    usuario_sei = db.Column(db.String(120))
 
     def set_password(self, password):
         self.password_hash = generate_password_hash(password)

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -37,6 +37,8 @@ def register():
         user.set_senha_sei(data['senha_sei'])
     if data.get('token_sei'):
         user.token_sei = data['token_sei']
+    if data.get('usuario_sei'):
+        user.usuario_sei = data['usuario_sei']
     db.session.add(user)
     db.session.commit()
     return jsonify({'msg': 'Usuário registrado com sucesso.'}), 201
@@ -101,6 +103,7 @@ def create_user():
     senha_siscom = data.get('senha_siscom')
     senha_sei = data.get('senha_sei')
     token_sei = data.get('token_sei')
+    usuario_sei = data.get('usuario_sei')
 
     if not username or not email or not password or not cpf:
         return jsonify({'msg': 'Dados inválidos'}), 400
@@ -120,6 +123,8 @@ def create_user():
         user.set_senha_sei(senha_sei)
     if token_sei:
         user.token_sei = token_sei
+    if usuario_sei:
+        user.usuario_sei = usuario_sei
     db.session.add(user)
     db.session.commit()
     return jsonify({'msg': 'Usuário criado com sucesso.'}), 201
@@ -166,6 +171,8 @@ def update_user(user_id):
         user.set_senha_sei(data['senha_sei'])
     if data.get('token_sei'):
         user.token_sei = data['token_sei']
+    if data.get('usuario_sei'):
+        user.usuario_sei = data['usuario_sei']
     db.session.commit()
     return jsonify({'msg': 'Usuário atualizado com sucesso.'}), 200
 

--- a/backend/app/routes/sei.py
+++ b/backend/app/routes/sei.py
@@ -1,0 +1,27 @@
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+import requests
+
+from ..models import User
+from ..services.sei_client import SEIClient
+
+bp = Blueprint("sei", __name__, url_prefix="/api/sei")
+
+
+@bp.route("/login", methods=["POST"])
+@jwt_required()
+def login():
+    user = User.query.get_or_404(get_jwt_identity())
+    data = request.get_json() or {}
+    usuario = data.get("usuario") or data.get("usuario_sei") or user.usuario_sei
+    senha = data.get("senha_sei") or data.get("password")
+    token = data.get("token_sei") or data.get("token")
+    if not usuario or not senha or not token:
+        return jsonify({"msg": "Credenciais inválidas"}), 400
+
+    client = SEIClient()
+    try:
+        client.login(usuario, senha, token)
+    except requests.HTTPError:
+        return jsonify({"msg": "Erro de autenticação no SEI"}), 401
+    return jsonify({"msg": "Autenticação SEI realizada com sucesso"}), 200

--- a/backend/app/services/sei_client.py
+++ b/backend/app/services/sei_client.py
@@ -1,0 +1,29 @@
+import requests
+
+
+class SEIClient:
+    """Client to handle authentication with the SEI system."""
+
+    LOGIN_URL = (
+        "https://sei.prf.gov.br/sip/login.php?sigla_sistema=SEI&sigla_orgao_sistema=PRF"
+    )
+
+    def __init__(self, session: requests.Session | None = None):
+        self.session = session or requests.Session()
+
+    def login(self, usuario: str, senha: str, token: str) -> None:
+        """Perform SEI login with password and second factor token."""
+
+        payload = {
+            "txtUsuario": usuario,
+            "pwdSenha": senha,
+            "selOrgao": "0",
+            "Acessar": "",
+            "hdnAcao": "2",
+        }
+        resp = self.session.post(self.LOGIN_URL, data=payload)
+        resp.raise_for_status()
+
+        payload2 = {"txtCodigoAcesso": token, "hdnAcao": "3"}
+        resp = self.session.post(self.LOGIN_URL, data=payload2)
+        resp.raise_for_status()

--- a/backend/migrations/versions/1b2e7c4e5b2d_add_usuario_sei.py
+++ b/backend/migrations/versions/1b2e7c4e5b2d_add_usuario_sei.py
@@ -1,0 +1,24 @@
+"""add usuario_sei column
+
+Revision ID: 1b2e7c4e5b2d
+Revises: dc56a59e0e34
+Create Date: 2025-07-03 00:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '1b2e7c4e5b2d'
+down_revision = 'dc56a59e0e34'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('user', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('usuario_sei', sa.String(length=120), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table('user', schema=None) as batch_op:
+        batch_op.drop_column('usuario_sei')

--- a/backend/tests/test_sei.py
+++ b/backend/tests/test_sei.py
@@ -1,0 +1,69 @@
+from app.models import User
+from app.extensions import db
+from app.services.sei_client import SEIClient
+
+
+def create_user():
+    user = User(
+        username="testuser",
+        email="test@example.com",
+        administrador=False,
+        cpf="12345678909",
+    )
+    user.set_password("password")
+    user.usuario_sei = "seiuser"
+    user.set_senha_sei("senha")
+    user.token_sei = "123"
+    db.session.add(user)
+    db.session.commit()
+    return user
+
+
+def get_token(client, email="test@example.com", password="password"):
+    response = client.post(
+        "/api/auth/login",
+        json={"email": email, "password": password},
+    )
+    assert response.status_code == 200
+    return response.get_json()["access_token"]
+
+
+def test_sei_login_calls_client(client, app, monkeypatch):
+    with app.app_context():
+        create_user()
+    token = get_token(client)
+
+    captured = {}
+
+    def fake_init(self, session=None):
+        pass
+
+    def fake_login(self, usuario, senha, tok):
+        captured["u"] = usuario
+        captured["s"] = senha
+        captured["t"] = tok
+
+    monkeypatch.setattr(SEIClient, "__init__", fake_init)
+    monkeypatch.setattr(SEIClient, "login", fake_login)
+
+    response = client.post(
+        "/api/sei/login",
+        json={"usuario": "seiuser", "senha_sei": "senha", "token_sei": "123"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 200
+    assert captured == {"u": "seiuser", "s": "senha", "t": "123"}
+
+
+def test_sei_login_missing_fields(client, app):
+    with app.app_context():
+        create_user()
+    token = get_token(client)
+
+    response = client.post(
+        "/api/sei/login",
+        json={},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 400

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -137,6 +137,7 @@
         <v-card-title>Autenticação SEI</v-card-title>
         <v-card-text>
           <v-form ref="seiForm" v-model="seiValid">
+            <v-text-field v-model="seiUsuario" label="Usuário" :rules="[rules.required]" />
             <v-text-field v-model="seiSenha" label="Senha SEI" type="password" :rules="[rules.required]" />
             <v-text-field v-model="seiToken" label="Token SEI" />
           </v-form>
@@ -166,6 +167,7 @@ import { useStore } from 'vuex'
 
 import { updateUser } from '../services/users'
 import { autoprfLogin } from '../services/autoprf'
+import { seiLogin } from '../services/sei'
 
 const props = defineProps({
   modelValue: {
@@ -189,6 +191,7 @@ const seiDialog = ref(false)
 const autoprfSenha = ref('')
 const autoprfToken = ref('')
 const siscomSenha = ref('')
+const seiUsuario = ref('')
 const seiSenha = ref('')
 const seiToken = ref('')
 
@@ -253,6 +256,12 @@ async function saveSei() {
   if (!seiForm.value?.validate()) return
   try {
     await updateUser(store.state.user.id, {
+      usuario_sei: seiUsuario.value,
+      senha_sei: seiSenha.value,
+      token_sei: seiToken.value
+    })
+    await seiLogin({
+      usuario: seiUsuario.value,
       senha_sei: seiSenha.value,
       token_sei: seiToken.value
     })

--- a/frontend/src/services/sei.js
+++ b/frontend/src/services/sei.js
@@ -1,0 +1,5 @@
+import api from './api'
+
+export function seiLogin(payload) {
+  return api.post('/api/sei/login', payload)
+}


### PR DESCRIPTION
## Summary
- add SEIClient service with two-step authentication
- expose `/api/sei/login` route
- save SEI username in the database
- include migration for new column
- update auth routes for the new field
- add frontend SEI login form and service
- register SEI blueprint and provide tests

## Testing
- `pip install -q python-dotenv`
- `pip install -q flask flask_sqlalchemy flask_jwt_extended flask_migrate flask_cors requests`
- `pip install -q beautifulsoup4`
- `pip install -q selenium`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866cbed9b08832e89e061a86095dd70