### PR TITLE
Remove stored autoprf and SEI tokens

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -9,11 +9,9 @@ class User(db.Model):
     administrador = db.Column(db.Boolean, default=False)
     cpf = db.Column(db.String(14), unique=True)
     senha_autoprf_hash = db.Column('senha_autoprf', db.String(120))
-    token_autoprf = db.Column(db.String(120))
     autoprf_session = db.Column(db.Text)
     senha_siscom_hash = db.Column('senha_siscom', db.String(120))
     senha_sei_hash = db.Column('senha_sei', db.String(120))
-    token_sei = db.Column(db.String(120))
     usuario_sei = db.Column(db.String(120))
 
     def set_password(self, password):

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -29,14 +29,10 @@ def register():
     user.set_password(data['password'])
     if data.get('senha_autoprf'):
         user.set_senha_autoprf(data['senha_autoprf'])
-    if data.get('token_autoprf'):
-        user.token_autoprf = data['token_autoprf']
     if data.get('senha_siscom'):
         user.set_senha_siscom(data['senha_siscom'])
     if data.get('senha_sei'):
         user.set_senha_sei(data['senha_sei'])
-    if data.get('token_sei'):
-        user.token_sei = data['token_sei']
     if data.get('usuario_sei'):
         user.usuario_sei = data['usuario_sei']
     db.session.add(user)
@@ -99,10 +95,8 @@ def create_user():
     administrador = data.get('administrador', False)
     cpf = data.get('cpf')
     senha_autoprf = data.get('senha_autoprf')
-    token_autoprf = data.get('token_autoprf')
     senha_siscom = data.get('senha_siscom')
     senha_sei = data.get('senha_sei')
-    token_sei = data.get('token_sei')
     usuario_sei = data.get('usuario_sei')
 
     if not username or not email or not password or not cpf:
@@ -115,14 +109,10 @@ def create_user():
     user.set_password(password)
     if senha_autoprf:
         user.set_senha_autoprf(senha_autoprf)
-    if token_autoprf:
-        user.token_autoprf = token_autoprf
     if senha_siscom:
         user.set_senha_siscom(senha_siscom)
     if senha_sei:
         user.set_senha_sei(senha_sei)
-    if token_sei:
-        user.token_sei = token_sei
     if usuario_sei:
         user.usuario_sei = usuario_sei
     db.session.add(user)
@@ -163,14 +153,10 @@ def update_user(user_id):
         user.set_password(data['password'])
     if data.get('senha_autoprf'):
         user.set_senha_autoprf(data['senha_autoprf'])
-    if data.get('token_autoprf'):
-        user.token_autoprf = data['token_autoprf']
     if data.get('senha_siscom'):
         user.set_senha_siscom(data['senha_siscom'])
     if data.get('senha_sei'):
         user.set_senha_sei(data['senha_sei'])
-    if data.get('token_sei'):
-        user.token_sei = data['token_sei']
     if data.get('usuario_sei'):
         user.usuario_sei = data['usuario_sei']
     db.session.commit()

--- a/backend/migrations/versions/07430eaa3e8b_remove_autoprf_sei_token.py
+++ b/backend/migrations/versions/07430eaa3e8b_remove_autoprf_sei_token.py
@@ -1,0 +1,26 @@
+"""remove autoprf and sei tokens
+
+Revision ID: 07430eaa3e8b
+Revises: 1b2e7c4e5b2d
+Create Date: 2025-07-04 00:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '07430eaa3e8b'
+down_revision = '1b2e7c4e5b2d'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('user', schema=None) as batch_op:
+        batch_op.drop_column('token_autoprf')
+        batch_op.drop_column('token_sei')
+
+
+def downgrade():
+    with op.batch_alter_table('user', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('token_sei', sa.String(length=120), nullable=True))
+        batch_op.add_column(sa.Column('token_autoprf', sa.String(length=120), nullable=True))

--- a/backend/tests/test_sei.py
+++ b/backend/tests/test_sei.py
@@ -13,7 +13,6 @@ def create_user():
     user.set_password("password")
     user.usuario_sei = "seiuser"
     user.set_senha_sei("senha")
-    user.token_sei = "123"
     db.session.add(user)
     db.session.commit()
     return user


### PR DESCRIPTION
## Summary
- stop persisting token_autoprf and token_sei
- remove token storage on user creation/update
- add migration dropping token columns
- adjust tests accordingly

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68670db2d048832eae90fb5ae1c78413