### PR TITLE
Implement SISCOM login feature

### DIFF
--- a/backend/app/services/siscom_client.py
+++ b/backend/app/services/siscom_client.py
@@ -5,8 +5,17 @@ import requests
 class SiscomClient:
     """Simple client to interact with the SISCOM service."""
 
-    def __init__(self, endpoint: str | None = None):
+    LOGIN_URL = "https://multa.prf.gov.br/multa2/"
+
+    def __init__(self, endpoint: str | None = None, session: requests.Session | None = None):
         self.endpoint = endpoint or os.getenv("SISCOM_ENDPOINT")
+        self.session = session or requests.Session()
+
+    def login(self, cpf: str, password: str) -> None:
+        """Authenticate against SISCOM using CPF and password."""
+        payload = {"username": cpf, "J_usemame": cpf, "j_password": password}
+        resp = self.session.post(self.LOGIN_URL, data=payload)
+        resp.raise_for_status()
 
     def pesquisar_ai(self, numero: str) -> dict:
         """Search for an Auto de Infracao and return a structured result."""

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -130,11 +130,12 @@
         <v-card-title>Autenticação SISCOM</v-card-title>
         <v-card-text>
             <v-form ref="siscomForm" v-model="siscomValid">
+              <v-text-field v-model="siscomPassword" label="Senha SISCOM" type="password" :rules="[rules.required]" />
             </v-form>
         </v-card-text>
         <v-card-actions>
           <v-spacer />
-          <v-btn text @click="siscomDialog = false">Cancelar</v-btn>
+          <v-btn text @click="siscomDialog = false; siscomPassword = ''">Cancelar</v-btn>
           <v-btn color="primary" :disabled="!siscomValid" @click="saveSiscom">Salvar</v-btn>
         </v-card-actions>
       </v-card>
@@ -174,6 +175,7 @@ import { useStore } from 'vuex'
 
 import { updateUser } from '../services/users'
 import { autoprfLogin } from '../services/autoprf'
+import { siscomLogin } from '../services/siscom'
 import { seiLogin } from '../services/sei'
 
 const props = defineProps({
@@ -197,6 +199,7 @@ const seiDialog = ref(false)
 
 const autoprfToken = ref('')
 const autoprfPassword = ref('')
+const siscomPassword = ref('')
 const seiUsuario = ref('')
 const seiToken = ref('')
 
@@ -243,7 +246,8 @@ async function saveAutoprf() {
 async function saveSiscom() {
   if (!siscomForm.value?.validate()) return
   try {
-    await updateUser(store.state.user.id, {})
+    await siscomLogin({ senha_siscom: siscomPassword.value })
+    siscomPassword.value = ''
     snackbarMsg.value = 'Dados SISCOM salvos com sucesso'
     snackbarColor.value = 'success'
     snackbar.value = true

--- a/frontend/src/services/siscom.js
+++ b/frontend/src/services/siscom.js
@@ -4,6 +4,10 @@ export function pesquisarAi(payload) {
   return api.post('/api/siscom/pesquisar_ai', payload)
 }
 
+export function siscomLogin(payload) {
+  return api.post('/api/siscom/login', payload)
+}
+
 export function buscarHistorico(payload) {
   return api.post('/api/siscom/historico', payload)
 }


### PR DESCRIPTION
## Summary
- support SISCOM login in backend client and routes
- expose siscomLogin service to the frontend
- add password field to SISCOM auth dialog and use new API
- add tests covering new SISCOM login endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68672891599c832ebb59b00268fb0949