### PR TITLE
Show cancel request result in emergency vehicles

### DIFF
--- a/frontend/src/views/VeiculosEmergencia.vue
+++ b/frontend/src/views/VeiculosEmergencia.vue
@@ -89,6 +89,7 @@
     >
       Solicitação de Cancelamento
     </v-btn>
+
   </v-container>
 </template>
 
@@ -318,9 +319,13 @@ async function enviarSolicitacao() {
     const { data } = await solicitarCancelamento(payload)
     if (data === 1 || data === true) {
       store.commit('showSnackbar', { msg: 'Solicitação enviada', color: 'success' })
+    } else {
+      store.commit('showSnackbar', { msg: 'Erro na solicitação' })
     }
+    limpar()
   } catch (err) {
     store.commit('showSnackbar', { msg: err.response?.data?.msg || 'Erro na solicitação' })
+    limpar()
   }
 }
 


### PR DESCRIPTION
## Summary
- display snackbar message after cancel request depending on response
- clear inputs once the request completes

## Testing
- `pip install -q -r backend/requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68681c32a6a4832e800ad4f3a0805acc