### PR TITLE
Handle AutoPRF session errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ The database file will be created under `backend/instance/`.
 
 ## AutoPRF Sessions
 
-When the backend detects that an AutoPRF request failed with status `401` or
+When the backend detects that an AutoPRF request fails with status `401` or
 `403`, it clears the stored session and responds with status `401` and the
-message `Sessão AutoPRF expirada`. The frontend intercepts this response,
-logs the user out and shows a snackbar saying `Sessão expirada` before
-redirecting to the home page.
+message `Sessão AutoPRF expirada`. The frontend now listens for this message or
+for `Sessão não iniciada` responses and displays a snackbar prompting the user
+to authenticate in AutoPRF.
 
 ## SISCOM
 

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -33,12 +33,19 @@ export function setupLoadingInterceptors(store) {
     },
     error => {
       store.commit('setLoading', false);
-      if (error.response && [401, 422].includes(error.response.status)) {
+      if (error.response) {
+        const status = error.response.status;
         const msg = error.response.data?.msg || error.response.data?.message || '';
-        if (/token has expired/i.test(msg)) {
+
+        if ([401, 422].includes(status) && /token has expired/i.test(msg)) {
           store.commit('logout');
           store.commit('showSnackbar', { msg: 'Sessão expirada' });
           router.push('/');
+        }
+
+        if ((status === 401 || status === 400) &&
+            (/Sessão AutoPRF expirada/i.test(msg) || /Sessão não iniciada/i.test(msg))) {
+          store.commit('showSnackbar', { msg: 'Faça login no AutoPRF' });
         }
       }
       return Promise.reject(error);

--- a/frontend/src/views/AutoInfracao.vue
+++ b/frontend/src/views/AutoInfracao.vue
@@ -356,7 +356,10 @@ async function buscar() {
     const { data } = await pesquisarAutoInfracao({ auto_infracao: numeroAi.value })
     store.commit('setAiResult', data)
   } catch (err) {
-    store.commit('showSnackbar', { msg: err.response?.data?.msg || 'Erro ao pesquisar AI' })
+    const msg = err.response?.data?.msg
+    if (!(/Sessão AutoPRF expirada/i.test(msg) || /Sessão não iniciada/i.test(msg))) {
+      store.commit('showSnackbar', { msg: msg || 'Erro ao pesquisar AI' })
+    }
     store.commit('setAiResult', null)
   }
 }

--- a/frontend/src/views/CancelamentoDuplicidade.vue
+++ b/frontend/src/views/CancelamentoDuplicidade.vue
@@ -170,6 +170,7 @@
 <script setup>
 import { ref, computed } from 'vue'
 import { onBeforeRouteLeave } from 'vue-router'
+import { useStore } from 'vuex'
 import { pesquisarAutoInfracao } from '../services/autoprf'
 
 const numeroAi1 = ref('')
@@ -182,6 +183,8 @@ const valid = ref(false)
 
 const rules = { required: v => !!v || 'Campo obrigatório' }
 
+const store = useStore()
+
 async function buscar() {
   if (!formRef.value?.validate()) return
   try {
@@ -192,7 +195,12 @@ async function buscar() {
     ai1.value = res1.data
     ai2.value = res2.data
   } catch (err) {
-    console.error(err)
+    const msg = err.response?.data?.msg
+    if (/Sessão AutoPRF expirada/i.test(msg) || /Sessão não iniciada/i.test(msg)) {
+      store.commit('showSnackbar', { msg: 'Faça login no AutoPRF' })
+    } else {
+      console.error(err)
+    }
     ai1.value = null
     ai2.value = null
   }

--- a/frontend/src/views/VeiculosEmergencia.vue
+++ b/frontend/src/views/VeiculosEmergencia.vue
@@ -232,7 +232,12 @@ async function buscar() {
       checked.value = true
     }
   } catch (err) {
-    console.error(err)
+    const msg = err.response?.data?.msg
+    if (/Sessão AutoPRF expirada/i.test(msg) || /Sessão não iniciada/i.test(msg)) {
+      store.commit('showSnackbar', { msg: 'Faça login no AutoPRF' })
+    } else {
+      console.error(err)
+    }
     envolvidos.value = []
     amparoInfo.value = null
     permitido.value = false
@@ -323,7 +328,12 @@ async function enviarSolicitacao() {
     }
     limpar()
   } catch (err) {
-    store.commit('showSnackbar', { msg: err.response?.data?.msg || 'Erro na solicitação' })
+    const msg = err.response?.data?.msg
+    if (/Sessão AutoPRF expirada/i.test(msg) || /Sessão não iniciada/i.test(msg)) {
+      store.commit('showSnackbar', { msg: 'Faça login no AutoPRF' })
+    } else {
+      store.commit('showSnackbar', { msg: msg || 'Erro na solicitação' })
+    }
     limpar()
   }
 }


### PR DESCRIPTION
## Summary
- show snackbar when AutoPRF session is missing or expired
- avoid duplicate snackbars in AutoPRF views
- document AutoPRF snackbar behavior

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686823b6ca68832e9783259f4d0a64de