### PR TITLE
Implement whitespace trimming for API inputs

### DIFF
--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -2,6 +2,7 @@ from flask import Blueprint, request, jsonify
 from ..models import User
 from ..extensions import db
 from flask_jwt_extended import create_access_token, jwt_required, get_jwt_identity
+from ..utils import strip_strings
 
 bp = Blueprint('auth', __name__, url_prefix='/api/auth')
 
@@ -11,7 +12,7 @@ def teste():
 
 @bp.route('/register', methods=['POST'])
 def register():
-    data = request.get_json()
+    data = strip_strings(request.get_json())
     if not data.get('cpf'):
         return jsonify({'msg': 'CPF é obrigatório'}), 400
     username = data.get('username')
@@ -35,7 +36,7 @@ def register():
 
 @bp.route('/login', methods=['POST'])
 def login():
-    data = request.get_json()
+    data = strip_strings(request.get_json())
     user = User.query.filter_by(email=data['email']).first()
     if user and user.check_password(data['password']):
         access_token = create_access_token(identity=str(user.id))
@@ -82,7 +83,7 @@ def create_user():
     if not current_user or not current_user.administrador:
         return jsonify({'msg': 'Acesso não autorizado'}), 403
 
-    data = request.get_json() or {}
+    data = strip_strings(request.get_json() or {})
     username = data.get('username')
     email = data.get('email')
     password = data.get('password')
@@ -125,7 +126,7 @@ def get_user(user_id):
 @jwt_required()
 def update_user(user_id):
     user = User.query.get_or_404(user_id)
-    data = request.get_json() or {}
+    data = strip_strings(request.get_json() or {})
     if 'username' in data:
         user.username = data['username']
     if 'email' in data:

--- a/backend/app/routes/autoprf.py
+++ b/backend/app/routes/autoprf.py
@@ -4,6 +4,7 @@ import requests
 
 from ..models import User
 from ..extensions import db
+from ..utils import strip_strings
 from ..services.autoprf_client import AutoPRFClient
 
 bp = Blueprint('autoprf', __name__, url_prefix='/api/autoprf')
@@ -12,7 +13,7 @@ bp = Blueprint('autoprf', __name__, url_prefix='/api/autoprf')
 @jwt_required()
 def login():
     user = User.query.get_or_404(get_jwt_identity())
-    data = request.get_json() or {}
+    data = strip_strings(request.get_json() or {})
     password = data.get('senha_autoprf') or data.get('password')
     token = data.get('token_autoprf') or data.get('token')
     if not password or not token:
@@ -40,7 +41,7 @@ def pesquisar_auto_infracao():
     if not user.autoprf_session:
         return jsonify({'msg': 'Sessão não iniciada'}), 400
 
-    data = request.get_json() or {}
+    data = strip_strings(request.get_json() or {})
     auto_infracao = data.get('auto_infracao')
     if not auto_infracao:
         return jsonify({'msg': 'Número de Auto de Infração não informado'}), 400
@@ -87,7 +88,7 @@ def solicitar_cancelamento():
     if not user.autoprf_session:
         return jsonify({'msg': 'Sessão não iniciada'}), 400
 
-    data = request.get_json() or {}
+    data = strip_strings(request.get_json() or {})
     numero = data.pop('numero', None) or data.pop('numero_ai', None)
     if not numero:
         return jsonify({'msg': 'Número de Auto de Infração não informado'}), 400

--- a/backend/app/routes/sei.py
+++ b/backend/app/routes/sei.py
@@ -4,6 +4,7 @@ import requests
 
 from ..models import User
 from ..services.sei_client import SEIClient
+from ..utils import strip_strings
 
 bp = Blueprint("sei", __name__, url_prefix="/api/sei")
 
@@ -12,7 +13,7 @@ bp = Blueprint("sei", __name__, url_prefix="/api/sei")
 @jwt_required()
 def login():
     user = User.query.get_or_404(get_jwt_identity())
-    data = request.get_json() or {}
+    data = strip_strings(request.get_json() or {})
     usuario = data.get("usuario") or data.get("usuario_sei") or user.usuario_sei
     senha = data.get("senha_sei") or data.get("password")
     token = data.get("token_sei") or data.get("token")

--- a/backend/app/routes/siscom.py
+++ b/backend/app/routes/siscom.py
@@ -5,6 +5,7 @@ from flask_jwt_extended import jwt_required, get_jwt_identity
 
 from ..models import User
 from ..services.siscom_client import SiscomClient
+from ..utils import strip_strings
 
 ENDPOINT = os.getenv("SISCOM_ENDPOINT")
 
@@ -15,7 +16,7 @@ bp = Blueprint("siscom", __name__, url_prefix="/api/siscom")
 @jwt_required()
 def login():
     user = User.query.get_or_404(get_jwt_identity())
-    data = request.get_json() or {}
+    data = strip_strings(request.get_json() or {})
     password = data.get("senha_siscom") or data.get("password")
     if not password:
         return jsonify({"msg": "Credenciais inválidas"}), 400
@@ -31,7 +32,7 @@ def login():
 @bp.route("/pesquisar_ai", methods=["POST"])
 @jwt_required()
 def pesquisar_ai():
-    data = request.get_json() or {}
+    data = strip_strings(request.get_json() or {})
     numero = data.get("numero") or data.get("auto_infracao")
     if not numero:
         return jsonify({"msg": "Número do AI não informado"}), 400
@@ -44,7 +45,7 @@ def pesquisar_ai():
 @bp.route("/historico", methods=["POST"])
 @jwt_required()
 def historico():
-    data = request.get_json() or {}
+    data = strip_strings(request.get_json() or {})
     numero = data.get("numero")
     if not numero:
         return jsonify({"msg": "Número do AI não informado"}), 400

--- a/backend/app/routes/veiculo.py
+++ b/backend/app/routes/veiculo.py
@@ -2,6 +2,7 @@ from flask import Blueprint, request, jsonify
 from flask_jwt_extended import jwt_required
 
 from ..services.veiculo_client import VeiculoClient
+from ..utils import strip_strings
 
 bp = Blueprint("veiculo", __name__, url_prefix="/api/veiculo")
 
@@ -9,7 +10,7 @@ bp = Blueprint("veiculo", __name__, url_prefix="/api/veiculo")
 @bp.route("/placa", methods=["POST"])
 @jwt_required()
 def consultar_por_placa():
-    data = request.get_json() or {}
+    data = strip_strings(request.get_json() or {})
     placa = data.get("placa")
     if not placa:
         return jsonify({"msg": "Placa não informada"}), 400

--- a/backend/app/utils/__init__.py
+++ b/backend/app/utils/__init__.py
@@ -1,0 +1,11 @@
+
+def strip_strings(obj):
+    """Recursively strip whitespace from all string values."""
+    if isinstance(obj, str):
+        return obj.strip()
+    if isinstance(obj, dict):
+        return {k: strip_strings(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [strip_strings(v) for v in obj]
+    return obj
+

--- a/backend/tests/test_siscom.py
+++ b/backend/tests/test_siscom.py
@@ -62,6 +62,33 @@ def test_pesquisar_ai_returns_structured_data(client, app, monkeypatch):
     assert response.get_json() == expected
 
 
+def test_pesquisar_ai_strips_whitespace(client, app, monkeypatch):
+    with app.app_context():
+        create_user()
+
+    token = get_token(client)
+    captured = {}
+
+    def fake_init(self, endpoint=None):
+        self.endpoint = endpoint
+
+    def fake_pesquisar(self, numero):
+        captured["numero"] = numero
+        return {}
+
+    monkeypatch.setattr(SiscomClient, "__init__", fake_init)
+    monkeypatch.setattr(SiscomClient, "pesquisar_ai", fake_pesquisar)
+
+    response = client.post(
+        "/api/siscom/pesquisar_ai",
+        json={"numero": " 123 "},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 200
+    assert captured.get("numero") == "123"
+
+
 def test_historico_returns_list(client, app, monkeypatch):
     with app.app_context():
         create_user()
@@ -89,6 +116,33 @@ def test_historico_returns_list(client, app, monkeypatch):
 
     assert response.status_code == 200
     assert response.get_json() == expected
+
+
+def test_historico_strips_whitespace(client, app, monkeypatch):
+    with app.app_context():
+        create_user()
+
+    token = get_token(client)
+    captured = {}
+
+    def fake_init(self, endpoint=None):
+        self.endpoint = endpoint
+
+    def fake_historico(self, numero):
+        captured["numero"] = numero
+        return []
+
+    monkeypatch.setattr(SiscomClient, "__init__", fake_init)
+    monkeypatch.setattr(SiscomClient, "historico", fake_historico)
+
+    response = client.post(
+        "/api/siscom/historico",
+        json={"numero": " 321 "},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 200
+    assert captured.get("numero") == "321"
 
 
 def test_siscom_login_calls_client(client, app, monkeypatch):

--- a/backend/tests/test_veiculo.py
+++ b/backend/tests/test_veiculo.py
@@ -49,6 +49,29 @@ def test_consultar_placa_returns_data(client, app, monkeypatch):
     assert response.get_json() == expected
 
 
+def test_consultar_placa_strips_whitespace(client, app, monkeypatch):
+    with app.app_context():
+        create_user()
+
+    token = get_token(client)
+    captured = {}
+
+    def fake_consultar(self, placa):
+        captured["placa"] = placa
+        return {}
+
+    monkeypatch.setattr(VeiculoClient, "consultar_placa", fake_consultar)
+
+    response = client.post(
+        "/api/veiculo/placa",
+        json={"placa": " ABC1234 "},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 200
+    assert captured.get("placa") == "ABC1234"
+
+
 def test_consultar_placa_requires_jwt(client, app, monkeypatch):
     with app.app_context():
         create_user()


### PR DESCRIPTION
## Summary
- add `strip_strings` utility to clean incoming JSON data
- sanitize request data in all API routes
- add regression tests ensuring whitespace is removed before processing

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68684e7acec0832eb23570753e71283a