### PR TITLE
Add VeiculosEmergenciaSiscom view

### DIFF
--- a/frontend/src/views/VeiculosEmergenciaSiscom.vue
+++ b/frontend/src/views/VeiculosEmergenciaSiscom.vue
@@ -1,0 +1,473 @@
+<template>
+  <v-container>
+    <v-row>
+      <v-col cols="12" md="4">
+        <v-card class="pa-4 mb-4" elevation="2" title="Auto de Infração">
+          <v-form ref="formRef" v-model="valid">
+            <v-text-field
+              v-model="numeroAi"
+              label="Número do Auto de Infração"
+              :rules="[rules.required]"
+            />
+            <v-btn color="primary" class="mt-2" @click="buscar" :disabled="!valid">
+              Pesquisar
+            </v-btn>
+            <v-btn color="secondary" class="mt-2 ml-2" @click="limpar">
+              Limpar
+            </v-btn>
+          </v-form>
+        </v-card>
+      </v-col>
+    </v-row>
+
+    <v-card v-if="localInfo" class="pa-4 mb-2" elevation="2">
+      <v-card-title>Local da Infração</v-card-title>
+      <v-card-text>
+        <v-row dense>
+          <v-col cols="12" md="6">
+            <v-text-field
+              :model-value="localInfo.codigo_municipio_uf"
+              label="Código/Município/UF"
+              readonly
+            />
+          </v-col>
+          <v-col cols="6" md="3">
+            <v-text-field
+              :model-value="localInfo.rodovia"
+              label="BR"
+              readonly
+            />
+          </v-col>
+          <v-col cols="6" md="3">
+            <v-text-field
+              :model-value="localInfo.km"
+              label="Km"
+              readonly
+            />
+          </v-col>
+          <v-col cols="6" md="3">
+            <v-text-field
+              :model-value="localInfo.sentido"
+              label="Sentido"
+              readonly
+            />
+          </v-col>
+          <v-col cols="6" md="3">
+            <v-text-field
+              :model-value="localInfo.data_hora"
+              label="Data/Hora"
+              readonly
+            />
+          </v-col>
+        </v-row>
+        <v-chip v-if="foraCircunscricao" color="red" class="mt-2" dark>
+          Fora da Circunscrição
+        </v-chip>
+        <v-chip v-else color="green" class="mt-2" dark>
+          Circunscrição do Rio Grande do Sul
+        </v-chip>
+      </v-card-text>
+    </v-card>
+
+    <v-card v-if="amparoInfo && !foraCircunscricao" class="pa-4 mb-2" elevation="2">
+      <v-card-title>Amparo legal</v-card-title>
+      <v-card-text>
+        <v-row dense>
+          <v-col cols="12" md="3">
+            <v-text-field
+              :model-value="amparoInfo.codigo"
+              label="Código"
+              readonly
+            />
+          </v-col>
+          <v-col cols="12" md="5">
+            <v-text-field
+              :model-value="amparoInfo.descricao"
+              label="Descrição"
+              readonly
+            />
+          </v-col>
+          <v-col cols="12" md="4">
+            <v-text-field
+              :model-value="amparoInfo.amparo"
+              label="Amparo legal"
+              readonly
+            />
+          </v-col>
+        </v-row>
+      </v-card-text>
+      <v-chip
+        v-if="checked"
+        class="mb-4"
+        :color="permitido ? 'green' : 'red'"
+        dark
+      >
+        {{
+          permitido
+            ? 'Enquadramento legal permitido'
+            : 'Enquadramento legal não permitido'
+        }}
+      </v-chip>
+    </v-card>
+    
+    <v-card v-if="envolvidos.length && !foraCircunscricao" class="pa-4" elevation="2">
+      <v-card-title>Envolvidos</v-card-title>
+      <v-card-text>
+        <v-row dense>
+          <v-col cols="12" md="6" v-for="env in envolvidos" :key="env.id">
+            <v-card class="mb-2">
+              <v-card-text>
+                <v-row dense>
+                  <v-col cols="12">
+                    <v-text-field
+                      :model-value="env.nome"
+                      label="Nome"
+                      readonly
+                    />
+                  </v-col>
+                  <v-col cols="12">
+                    <v-text-field
+                      :model-value="env.envolvimentoAuto || env.envolvimentoProcesso || env.envolvimento"
+                      label="Envolvimento"
+                      readonly
+                    />
+                  </v-col>
+                  <v-col cols="6">
+                    <v-text-field
+                      :model-value="env.tipoDocumento"
+                      label="Tipo Documento"
+                      readonly
+                    />
+                  </v-col>
+                  <v-col cols="6">
+                    <v-text-field
+                      :model-value="env.numeroDocumento"
+                      label="Número Documento"
+                      readonly
+                    />
+                  </v-col>
+                </v-row>
+                <v-chip
+                  v-if="showInstituicao(env)"
+                  color="green"
+                  class="mt-2"
+                >
+                  Proprietário/possuidor previsto em lei:
+                  {{ instituicaoNome(env.numeroDocumento) }}
+                </v-chip>
+                <v-chip
+                  v-else
+                  color="red"
+                  class="mt-2"
+                >
+                  Proprietário/possuidor não previsto em lei
+                </v-chip>
+              </v-card-text>
+            </v-card>
+          </v-col>
+        </v-row>
+      </v-card-text>
+    </v-card>
+    <v-form
+      v-if="!foraCircunscricao && ((requireManualJustificativa && !justificativa) || editJustificativa)"
+      ref="manualFormRef"
+      v-model="manualValid"
+      class="mt-4"
+    >
+      <v-card class="pa-4" elevation="2">
+        <v-card-title class="d-flex justify-space-between align-center">
+          Justificativa
+          <v-btn
+            v-if="editJustificativa"
+            size="small"
+            variant="text"
+            color="secondary"
+            @click="editJustificativa = false"
+          >
+            Cancelar
+          </v-btn>
+        </v-card-title>
+        <v-card-text>
+          <v-textarea
+            v-model="motivoManual"
+            label="Motivo"
+            :rules="[rules.required]"
+          />
+          <v-text-field
+            v-model="justificativaManual"
+            label="Justificativa por não ter substituto"
+            :rules="[rules.required]"
+          />
+        </v-card-text>
+      </v-card>
+    </v-form>
+    <v-card v-if="justificativa && !editJustificativa && !foraCircunscricao" class="pa-4 mb-2" elevation="2">
+      <v-card-title class="d-flex justify-space-between align-center">
+        Justificativa
+        <v-btn size="small" @click="enableManualEdit" color="primary">Alterar</v-btn>
+      </v-card-title>
+      <v-card-text>
+        <v-row dense>
+          <v-col cols="12" md="4">
+            <v-text-field
+              :model-value="justificativa.orgao"
+              label="Órgão"
+              readonly
+            />
+          </v-col>
+          <v-col cols="12" md="8">
+            <v-text-field
+              :model-value="justificativa.motivo"
+              label="Motivo"
+              readonly
+            />
+          </v-col>
+          <v-col cols="12">
+            <v-textarea
+              :model-value="justificativa.justificativa"
+              label="Justificativa"
+              readonly
+            />
+          </v-col>
+        </v-row>
+      </v-card-text>
+    </v-card>
+    <v-btn
+      v-if="!foraCircunscricao && (justificativa || requireManualJustificativa)"
+      color="primary"
+      class="mt-4"
+      :disabled="!justificativa && !manualValid"
+      @click="enviarSolicitacao"
+    >
+      Solicitar Cancelamento
+    </v-btn>
+
+  </v-container>
+</template>
+
+<script setup>
+import { ref, computed } from 'vue'
+import { useStore } from 'vuex'
+import { onBeforeRouteLeave } from 'vue-router'
+import { pesquisarAi } from '../services/siscom'
+import { consultarPlaca } from '../services/veiculo'
+
+const numeroAi = ref('')
+const envolvidos = ref([])
+const amparoInfo = ref(null)
+const localInfo = ref(null)
+const permitido = ref(false)
+const checked = ref(false)
+const formRef = ref(null)
+const valid = ref(false)
+const autoId = ref(null)
+const idProcesso = ref(null)
+const motivoManual = ref('')
+const justificativaManual = ref('')
+const manualValid = ref(false)
+const manualFormRef = ref(null)
+const editJustificativa = ref(false)
+const store = useStore()
+
+const foraCircunscricao = computed(() => {
+  const str = localInfo.value?.codigo_municipio_uf || ''
+  const match = str.match(/\/([A-Za-z]{2})$/)
+  if (!match) return false
+  return match[1].toUpperCase() !== 'RS'
+})
+
+const rules = { required: v => !!v || 'Campo obrigatório' }
+
+const instituicoes = {
+  '89175541000164': 'Brigada Militar',
+  '00058163000125': 'Polícia Civil',
+  '28610005000155': 'Corpo de Bombeiros',
+  '02510700000151': 'EPTC',
+  '00394429000179': 'PRF',
+  '07963160000130': 'SUSEPE',
+  '09734605000187': 'Polícia Legislativa',
+  '87934675000196': 'Estado do Rio Grande do Sul'
+}
+
+const justificativas = {
+  '00394429000179': {
+    orgao: 'PRF',
+    motivo:
+      'Enquadramento no art. 280, § 6º do CTB, por se tratar de viatura oficial de órgão policial (Polícia Rodoviária Federal). Requerimento em anexo',
+    justificativa: 'Viatura policial'
+  },
+  '00058163000125': {
+    orgao: 'Polícia Civil',
+    motivo:
+      'Enquadramento no art. 280, § 6º do CTB, por se tratar de viatura oficial de órgão policial (Polícia Civil do Estado do Rio Grande do Sul). Requerimento em anexo',
+    justificativa: 'Viatura policial'
+  },
+  '09734605000187': {
+    orgao: 'Polícia Legislativa',
+    motivo:
+      'Enquadramento no art. 280, § 6º do CTB, por se tratar de viatura oficial de órgão policial (Polícia Legislativa). Requerimento em anexo',
+    justificativa: 'Viatura policial'
+  },
+  '07963160000130': {
+    orgao: 'SUSEPE',
+    motivo:
+      'Enquadramento no art. 280, § 6º do CTB, por se tratar de viatura oficial da polícia penal (Superintendência dos Serviços Penitenciários do Estado do Rio Grande do Sul). Requerimento em anexo',
+    justificativa: 'Viatura policial'
+  },
+  '89175541000164': {
+    orgao: 'Brigada Militar',
+    motivo:
+      'Enquadramento no art. 280, § 6º do CTB, por se tratar de viatura oficial de órgão policial (Brigada Militar do Estado do Rio Grande do Sul). Requerimento em anexo',
+    justificativa: 'Viatura policial'
+  },
+  '87934675000196': {
+    orgao: 'Estado do Rio Grande do Sul',
+    motivo:
+      'Enquadramento no art. 280, § 6º do CTB, por se tratar de viatura oficial de órgão policial (Brigada Militar do Estado do Rio Grande do Sul). Requerimento em anexo',
+    justificativa: 'Viatura policial'
+  },
+  '28610005000155': {
+    orgao: 'Corpo de Bombeiros Militar do Estado do Rio Grande do Sul',
+    motivo:
+      'Enquadramento no art. 280, § 6º do CTB, por se tratar de viatura oficial de órgão destinados a socorro de incêndio e salvamento (Corpo de Bombeiros Militar do Estado do Rio Grande do Sul). Requerimento em anexo',
+    justificativa: 'Viatura policial'
+  }
+}
+
+// Relação de códigos com enquadramento legal permitido
+const codigosPermitidos = ['745-50', '746-30', '747-10']
+const codigosPermitidosDigits = codigosPermitidos.map(c => c.replace(/\D/g, ''))
+
+
+function sanitize(cnpj) {
+  return (cnpj || '').replace(/\D/g, '')
+}
+
+function instituicaoNome(cnpj) {
+  return instituicoes[sanitize(cnpj)]
+}
+
+function showInstituicao(env) {
+  const envolvimento = (env.envolvimentoAuto || env.envolvimentoProcesso || env.envolvimento || '').toLowerCase()
+  if (!/propriet[aá]rio|possuidor/.test(envolvimento)) return false
+  return !!instituicaoNome(env.numeroDocumento)
+}
+
+const justificativa = computed(() => {
+  for (const env of envolvidos.value) {
+    const envolvimento = (env.envolvimentoAuto || env.envolvimentoProcesso || env.envolvimento || '').toLowerCase()
+    if (!/propriet[aá]rio|possuidor/.test(envolvimento)) continue
+    const j = justificativas[sanitize(env.numeroDocumento)]
+    if (j) return j
+  }
+  return null
+})
+
+const requireManualJustificativa = computed(() => {
+  for (const env of envolvidos.value) {
+    const envolvimento = (env.envolvimentoAuto || env.envolvimentoProcesso || env.envolvimento || '').toLowerCase()
+    if (!/propriet[aá]rio|possuidor/.test(envolvimento)) continue
+    const cnpj = sanitize(env.numeroDocumento)
+    if (!instituicoes[cnpj]) return true
+  }
+  return false
+})
+
+async function buscar() {
+  if (!formRef.value?.validate()) return
+  checked.value = false
+  try {
+    const { data } = await pesquisarAi({ numero: numeroAi.value })
+
+    if (data) {
+      localInfo.value = data.local || null
+      const cd = data.infracao?.codigo_descricao || ''
+      const [codPart, ...descParts] = cd.split(/\s*-\s*/)
+      const codigo = codPart?.trim() || ''
+      const descricao = descParts.join(' - ').trim()
+      amparoInfo.value = cd
+        ? {
+            codigo,
+            descricao,
+            amparo: data.infracao?.amparo_legal || ''
+          }
+        : null
+
+      const digits = codigo.replace(/\D/g, '')
+      permitido.value = codigosPermitidosDigits.includes(digits)
+      checked.value = true
+
+      envolvidos.value = []
+      if (data.veiculo?.placa) {
+        try {
+          const res = await consultarPlaca({ placa: data.veiculo.placa })
+          const v = res.data || {}
+          if (v.nomeProprietario || v.documentoProprietario) {
+            envolvidos.value = [
+              {
+                id: 1,
+                nome: v.nomeProprietario,
+                envolvimento: 'Proprietário',
+                tipoDocumento: v.descricaoTipoDocumentoProprietario || v.tipo_documento,
+                numeroDocumento: v.documentoProprietario
+              }
+            ]
+          }
+        } catch (e) {
+          console.error(e)
+        }
+      }
+    } else {
+      envolvidos.value = []
+      amparoInfo.value = null
+      localInfo.value = null
+      permitido.value = false
+      checked.value = true
+    }
+  } catch (err) {
+    store.commit('showSnackbar', { msg: err.response?.data?.msg || 'Erro na pesquisa' })
+    console.error(err)
+    envolvidos.value = []
+    amparoInfo.value = null
+    localInfo.value = null
+    permitido.value = false
+    checked.value = true
+  }
+}
+
+function enableManualEdit() {
+  if (justificativa.value) {
+    motivoManual.value = justificativa.value.motivo
+    justificativaManual.value = justificativa.value.justificativa
+  }
+  editJustificativa.value = true
+}
+
+function limpar() {
+  numeroAi.value = ''
+  envolvidos.value = []
+  amparoInfo.value = null
+  localInfo.value = null
+  permitido.value = false
+  checked.value = false
+  motivoManual.value = ''
+  justificativaManual.value = ''
+  manualValid.value = false
+  editJustificativa.value = false
+  formRef.value?.resetValidation()
+  manualFormRef.value?.resetValidation()
+}
+
+onBeforeRouteLeave(() => {
+  limpar()
+})
+
+function removeAccents(str) {
+  return (str || '').normalize('NFD').replace(/\p{Diacritic}/gu, '')
+}
+
+async function enviarSolicitacao() {
+  store.commit('showSnackbar', { msg: 'Funcionalidade indisponível' })
+}
+
+</script>


### PR DESCRIPTION
## Summary
- create VeiculosEmergenciaSiscom.vue from VeiculosEmergencia.vue
- call SISCOM `pesquisarAi` and `consultarPlaca` when searching
- show proprietor info from vehicle lookup
- remove AutoPRF session checks
- disable cancellation action

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d4fba22a0832ea584a1d20971c0e6