### PR TITLE
Add historico endpoint for AutoPRF

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ to authenticate in AutoPRF.
 
 - `POST /api/autoprf/solicitacao/cancelamento` – envia uma solicitação de
   cancelamento de Auto de Infração utilizando a sessão autenticada.
+- `GET /api/autoprf/historico/<id_processo>` – obtém o histórico do processo
+  de Auto de Infração utilizando a sessão autenticada.
 
 O frontend inclui um botão **Solicitação de Cancelamento** na tela de
 Veículos de Emergência que envia a requisição e exibe uma snackbar de sucesso

--- a/backend/app/services/autoprf_client.py
+++ b/backend/app/services/autoprf_client.py
@@ -210,3 +210,17 @@ class AutoPRFClient:
         print(resp)
         resp.raise_for_status()
         return resp.json() if resp.content else True
+
+    def historico(self, id_processo: int | str) -> list:
+        """Return the list of status updates for a given processo."""
+
+        headers = {}
+        if self.jwt_token:
+            headers["Authorization"] = f"Bearer {self.jwt_token}"
+
+        resp = requests.get(
+            f"{self.BASE_URL}/auto-infracao/{id_processo}/historico",
+            headers=headers,
+        )
+        resp.raise_for_status()
+        return resp.json() if resp.content else []


### PR DESCRIPTION
## Summary
- implement `historico` method in `AutoPRFClient`
- add `/historico/<id_processo>` route
- document new route
- test new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fb88c9bdc832ebe26d39d840f0379