### PR TITLE
Add obterHistorico API call

### DIFF
--- a/frontend/src/services/autoprf.js
+++ b/frontend/src/services/autoprf.js
@@ -15,3 +15,7 @@ export function obterEnvolvidos(id) {
 export function solicitarCancelamento(payload) {
   return api.post('/api/autoprf/solicitacao/cancelamento', payload)
 }
+
+export function obterHistorico(idProcesso) {
+  return api.get(`/api/autoprf/historico/${idProcesso}`)
+}


### PR DESCRIPTION
## Summary
- add `obterHistorico` method to the AutoPRF service

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fbb6f341c832ea39cf2ddbe9de701