### PR TITLE
Ajusta layout de resposta de cancelamento

### DIFF
--- a/frontend/src/views/VeiculosEmergencia.vue
+++ b/frontend/src/views/VeiculosEmergencia.vue
@@ -247,17 +247,28 @@
       class="mt-4 pa-4"
       elevation="2"
     >
-      <div class="mb-2"><strong>Número do Protocolo:</strong> {{ cancelamentoInfo.numeroProtocolo }}</div>
-      <v-data-table
-        :headers="historicoHeaders"
-        :items="cancelamentoInfo.eventos"
-        :items-per-page="-1"
-        hide-default-footer
-      >
-        <template #item.dataHora="{ item }">
-          {{ new Date(item.dataHora).toLocaleString('pt-BR') }}
-        </template>
-      </v-data-table>
+      <v-card-title>Solicitação de Cancelamento</v-card-title>
+      <v-card-text>
+        <v-row dense>
+          <v-col cols="12" md="4">
+            <v-text-field
+              :model-value="cancelamentoInfo.numeroProtocolo"
+              label="Número do Protocolo"
+              readonly
+            />
+          </v-col>
+        </v-row>
+        <v-data-table
+          :headers="historicoHeaders"
+          :items="cancelamentoInfo.eventos"
+          :items-per-page="-1"
+          hide-default-footer
+        >
+          <template #item.dataHora="{ item }">
+            {{ new Date(item.dataHora).toLocaleString('pt-BR') }}
+          </template>
+        </v-data-table>
+      </v-card-text>
     </v-card>
     <v-alert v-else-if="cancelamentoInfo === false" type="warning" class="mt-4">
       Não há registro de protocolo da solicitação


### PR DESCRIPTION
## Summary
- ajusta layout do card de resposta do cancelamento para seguir mesmo formato dos demais

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fc3c4eccc832ea01d535779610ef2