### PR TITLE
Remove duplicate endpoint entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ to authenticate in AutoPRF.
   solicitação de cancelamento.
 - `GET /api/autoprf/historico/<id_processo>` – obtém o histórico do processo
   de Auto de Infração utilizando a sessão autenticada.
-- `GET /api/autoprf/historico/<idProcesso>` – retorna o histórico do processo do AutoPRF.
 
 O frontend inclui um botão **Solicitação de Cancelamento** na tela de
 Veículos de Emergência que envia a requisição e exibe uma snackbar de sucesso


### PR DESCRIPTION
## Summary
- fix documentation by removing duplicate AutoPRF historico endpoint in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877e78f0dd4832e936d0a2a67a59917