### PR TITLE
Show upload card after AI query

### DIFF
--- a/frontend/src/views/VeiculosEmergencia.vue
+++ b/frontend/src/views/VeiculosEmergencia.vue
@@ -168,11 +168,23 @@
         </v-row>
       </v-card-text>
     </v-card>
-    <v-file-input
-      accept="application/pdf"
-      v-model="arquivoPdf"
-      label="Arquivo PDF"
-    />
+    <v-card v-if="checked" class="pa-4 mb-2" elevation="2">
+      <v-card-title>Anexar Arquivo</v-card-title>
+      <v-card-text>
+        <v-file-input
+          accept="application/pdf"
+          v-model="arquivoPdf"
+          label="Arquivo PDF"
+        />
+        <v-alert
+          v-if="uploadStatus !== null"
+          :type="uploadStatus ? 'success' : 'error'"
+          class="mt-2"
+        >
+          {{ uploadStatus ? 'Arquivo enviado com sucesso' : 'Erro ao enviar arquivo' }}
+        </v-alert>
+      </v-card-text>
+    </v-card>
     <v-form
       v-if="!foraCircunscricao && ((requireManualJustificativa && !justificativa) || editJustificativa)"
       ref="manualFormRef"
@@ -533,9 +545,14 @@ async function enviarSolicitacao() {
       try {
         await anexarArquivo(idProcesso.value, arquivoPdf.value)
         uploadStatus.value = true
+        store.commit('showSnackbar', {
+          msg: 'Arquivo enviado com sucesso',
+          color: 'success'
+        })
       } catch (e) {
         console.error(e)
         uploadStatus.value = false
+        store.commit('showSnackbar', { msg: 'Erro ao enviar arquivo' })
       }
     } else {
       uploadStatus.value = null


### PR DESCRIPTION
## Summary
- display PDF upload section only after AI lookup completes
- notify user via snackbar about upload success or failure

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877ebdc5fe8832eaeb5f493be8872e5