### PR TITLE
Store SEI login session

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -9,6 +9,7 @@ class User(db.Model):
     administrador = db.Column(db.Boolean, default=False)
     cpf = db.Column(db.String(14), unique=True)
     autoprf_session = db.Column(db.Text)
+    sei_session = db.Column(db.Text)
     usuario_sei = db.Column(db.String(120))
 
     def set_password(self, password):

--- a/backend/app/routes/sei.py
+++ b/backend/app/routes/sei.py
@@ -1,6 +1,9 @@
 from flask import Blueprint, jsonify, request
+import json
 from flask_jwt_extended import jwt_required, get_jwt_identity
 import requests
+
+from ..extensions import db
 
 from ..models import User
 from ..services.sei_client import SEIClient
@@ -25,6 +28,10 @@ def login():
         client.login(usuario, senha, token)
     except requests.HTTPError:
         return jsonify({"msg": "Erro de autenticação no SEI"}), 401
+
+    user.sei_session = json.dumps(requests.utils.dict_from_cookiejar(client.session.cookies))
+    user.usuario_sei = usuario
+    db.session.commit()
     return jsonify({"msg": "Autenticação SEI realizada com sucesso"}), 200
 
 
@@ -33,19 +40,21 @@ def login():
 def tipos_processo():
     """Retorna os tipos de processos disponíveis no SEI."""
     user = User.query.get_or_404(get_jwt_identity())
-    data = strip_strings(request.get_json() or {})
-    usuario = data.get("usuario") or data.get("usuario_sei") or user.usuario_sei
-    senha = data.get("senha_sei") or data.get("password")
-    token = data.get("token_sei") or data.get("token")
-    if not usuario or not senha or not token:
-        return jsonify({"msg": "Credenciais inválidas"}), 400
 
-    client = SEIClient()
+    if not user.sei_session:
+        return jsonify({"msg": "Sessão não iniciada"}), 400
+
+    session = requests.Session()
+    session.cookies = requests.utils.cookiejar_from_dict(json.loads(user.sei_session))
+    client = SEIClient(session=session)
     try:
-        client.login(usuario, senha, token)
         tipos = client.list_process_types()
-    except requests.HTTPError:
-        return jsonify({"msg": "Erro de autenticação no SEI"}), 401
+    except requests.HTTPError as e:
+        if e.response is not None and e.response.status_code in (401, 403):
+            user.sei_session = None
+            db.session.commit()
+            return jsonify({"msg": "Sessão SEI expirada"}), 401
+        raise
     except Exception:
         return jsonify({"msg": "Erro ao listar tipos de processo"}), 400
 
@@ -59,22 +68,24 @@ def criar_processo():
     user = User.query.get_or_404(get_jwt_identity())
     data = strip_strings(request.get_json() or {})
 
-    usuario = data.get("usuario") or data.get("usuario_sei") or user.usuario_sei
-    senha = data.get("senha_sei") or data.get("password")
-    token = data.get("token_sei") or data.get("token")
     tipo_id = data.get("tipo_id")
     tipo_nome = data.get("tipo_nome")
     descricao = data.get("descricao")
 
-    if not usuario or not senha or not token or not tipo_id or not tipo_nome or not descricao:
+    if not user.sei_session or not tipo_id or not tipo_nome or not descricao:
         return jsonify({"msg": "Dados incompletos"}), 400
 
-    client = SEIClient()
+    session = requests.Session()
+    session.cookies = requests.utils.cookiejar_from_dict(json.loads(user.sei_session))
+    client = SEIClient(session=session)
     try:
-        client.login(usuario, senha, token)
         resp = client.create_process(tipo_id, tipo_nome, descricao)
         resp.raise_for_status()
-    except requests.HTTPError:
+    except requests.HTTPError as e:
+        if e.response is not None and e.response.status_code in (401, 403):
+            user.sei_session = None
+            db.session.commit()
+            return jsonify({"msg": "Sessão SEI expirada"}), 401
         return jsonify({"msg": "Erro ao criar processo no SEI"}), 400
 
     return jsonify({"msg": "Processo criado com sucesso"}), 200

--- a/backend/migrations/versions/01bedea2b1bb_add_sei_session.py
+++ b/backend/migrations/versions/01bedea2b1bb_add_sei_session.py
@@ -1,0 +1,17 @@
+"""add sei session field"""
+
+revision = '01bedea2b1bb'
+down_revision = '5e1d08683305'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('user', sa.Column('sei_session', sa.Text(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('user', 'sei_session')

--- a/backend/tests/test_sei.py
+++ b/backend/tests/test_sei.py
@@ -2,6 +2,7 @@ from app.models import User
 from app.extensions import db
 from app.services.sei_client import SEIClient
 import requests
+import json
 from unittest.mock import MagicMock
 
 
@@ -36,7 +37,7 @@ def test_sei_login_calls_client(client, app, monkeypatch):
     captured = {}
 
     def fake_init(self, session=None):
-        pass
+        self.session = requests.Session()
 
     def fake_login(self, usuario, senha, tok):
         captured["u"] = usuario
@@ -56,6 +57,33 @@ def test_sei_login_calls_client(client, app, monkeypatch):
     assert captured == {"u": "seiuser", "s": "senha", "t": "123"}
 
 
+def test_sei_login_stores_session(client, app, monkeypatch):
+    with app.app_context():
+        user = create_user()
+        user_id = user.id
+
+    def fake_init(self, session=None):
+        self.session = requests.Session()
+
+    def fake_login(self, usuario, senha, tok):
+        self.session.cookies.set("SID", "ABC")
+
+    monkeypatch.setattr(SEIClient, "__init__", fake_init)
+    monkeypatch.setattr(SEIClient, "login", fake_login)
+
+    token = get_token(client)
+    resp = client.post(
+        "/api/sei/login",
+        json={"usuario": "seiuser", "senha_sei": "pass", "token_sei": "1"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert resp.status_code == 200
+    with app.app_context():
+        updated = User.query.get(user_id)
+        assert json.loads(updated.sei_session)["SID"] == "ABC"
+
+
 def test_sei_login_strips_whitespace(client, app, monkeypatch):
     with app.app_context():
         create_user()
@@ -64,7 +92,7 @@ def test_sei_login_strips_whitespace(client, app, monkeypatch):
     captured = {}
 
     def fake_init(self, session=None):
-        pass
+        self.session = requests.Session()
 
     def fake_login(self, usuario, senha, tok):
         captured["u"] = usuario
@@ -99,51 +127,43 @@ def test_sei_login_missing_fields(client, app):
 
 def test_list_process_types_calls_client(client, app, monkeypatch):
     with app.app_context():
-        create_user()
+        user = create_user()
+        user.sei_session = json.dumps({"SID": "ABC"})
+        db.session.commit()
     token = get_token(client)
 
     captured = {}
 
     def fake_init(self, session=None):
-        pass
-
-    def fake_login(self, usuario, senha, tok):
-        captured["u"] = usuario
-        captured["s"] = senha
-        captured["t"] = tok
+        captured["cookie"] = session.cookies.get("SID")
 
     def fake_list(self):
         return [{"id": "1", "text": "Proc"}]
 
     monkeypatch.setattr(SEIClient, "__init__", fake_init)
-    monkeypatch.setattr(SEIClient, "login", fake_login)
     monkeypatch.setattr(SEIClient, "list_process_types", fake_list)
 
     response = client.post(
         "/api/sei/tipos",
-        json={"usuario": "seiuser", "senha_sei": "senha", "token_sei": "123"},
         headers={"Authorization": f"Bearer {token}"},
     )
 
     assert response.status_code == 200
     assert response.get_json() == [{"id": "1", "text": "Proc"}]
-    assert captured == {"u": "seiuser", "s": "senha", "t": "123"}
+    assert captured == {"cookie": "ABC"}
 
 
 def test_create_process_calls_client(client, app, monkeypatch):
     with app.app_context():
-        create_user()
+        user = create_user()
+        user.sei_session = json.dumps({"SID": "ABC"})
+        db.session.commit()
     token = get_token(client)
 
     captured = {}
 
     def fake_init(self, session=None):
-        pass
-
-    def fake_login(self, usuario, senha, tok):
-        captured["u"] = usuario
-        captured["s"] = senha
-        captured["t"] = tok
+        captured["cookie"] = session.cookies.get("SID")
 
     def fake_create(self, tipo_id, tipo_nome, desc):
         captured["id"] = tipo_id
@@ -154,13 +174,9 @@ def test_create_process_calls_client(client, app, monkeypatch):
         return resp
 
     monkeypatch.setattr(SEIClient, "__init__", fake_init)
-    monkeypatch.setattr(SEIClient, "login", fake_login)
     monkeypatch.setattr(SEIClient, "create_process", fake_create)
 
     payload = {
-        "usuario": "seiuser",
-        "senha_sei": "senha",
-        "token_sei": "123",
         "tipo_id": "7",
         "tipo_nome": "Teste",
         "descricao": "desc",
@@ -173,65 +189,53 @@ def test_create_process_calls_client(client, app, monkeypatch):
 
     assert response.status_code == 200
     assert response.get_json() == {"msg": "Processo criado com sucesso"}
-    assert captured == {
-        "u": "seiuser",
-        "s": "senha",
-        "t": "123",
-        "id": "7",
-        "nome": "Teste",
-        "desc": "desc",
-    }
+    assert captured == {"cookie": "ABC", "id": "7", "nome": "Teste", "desc": "desc"}
 
 
 def test_tipos_invokes_login_and_list(client, app, monkeypatch):
     """Ensure list endpoint calls SEIClient methods."""
     with app.app_context():
-        create_user()
+        user = create_user()
+        user.sei_session = json.dumps({"SID": "AB"})
+        db.session.commit()
     token = get_token(client)
 
     def fake_init(self, session=None):
         pass
 
-    login_mock = MagicMock()
     list_mock = MagicMock(return_value=[{"id": "1", "text": "Proc"}])
 
     monkeypatch.setattr(SEIClient, "__init__", fake_init)
-    monkeypatch.setattr(SEIClient, "login", login_mock)
     monkeypatch.setattr(SEIClient, "list_process_types", list_mock)
 
     resp = client.post(
         "/api/sei/tipos",
-        json={"usuario": "seiuser", "senha_sei": "senha", "token_sei": "123"},
         headers={"Authorization": f"Bearer {token}"},
     )
 
     assert resp.status_code == 200
-    login_mock.assert_called_once_with("seiuser", "senha", "123")
     list_mock.assert_called_once_with()
 
 
 def test_processos_invokes_login_and_create(client, app, monkeypatch):
     """Ensure process creation endpoint calls SEIClient methods with args."""
     with app.app_context():
-        create_user()
+        user = create_user()
+        user.sei_session = json.dumps({"SID": "AB"})
+        db.session.commit()
     token = get_token(client)
 
     def fake_init(self, session=None):
         pass
 
-    login_mock = MagicMock()
     resp_obj = requests.Response()
     resp_obj.status_code = 200
     create_mock = MagicMock(return_value=resp_obj)
 
     monkeypatch.setattr(SEIClient, "__init__", fake_init)
-    monkeypatch.setattr(SEIClient, "login", login_mock)
     monkeypatch.setattr(SEIClient, "create_process", create_mock)
 
     payload = {
-        "usuario": "seiuser",
-        "senha_sei": "senha",
-        "token_sei": "123",
         "tipo_id": "7",
         "tipo_nome": "Teste",
         "descricao": "desc",
@@ -243,5 +247,36 @@ def test_processos_invokes_login_and_create(client, app, monkeypatch):
     )
 
     assert resp.status_code == 200
-    login_mock.assert_called_once_with("seiuser", "senha", "123")
     create_mock.assert_called_once_with("7", "Teste", "desc")
+
+
+def test_sei_session_expired(client, app, monkeypatch):
+    with app.app_context():
+        user = create_user()
+        user.sei_session = json.dumps({"SID": "AB"})
+        db.session.commit()
+        uid = user.id
+
+    token = get_token(client)
+
+    def fake_init(self, session=None):
+        pass
+
+    def fake_list(self):
+        resp = requests.Response()
+        resp.status_code = 401
+        raise requests.HTTPError(response=resp)
+
+    monkeypatch.setattr(SEIClient, "__init__", fake_init)
+    monkeypatch.setattr(SEIClient, "list_process_types", fake_list)
+
+    resp = client.post(
+        "/api/sei/tipos",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert resp.status_code == 401
+    assert resp.get_json() == {"msg": "Sessão SEI expirada"}
+    with app.app_context():
+        updated = User.query.get(uid)
+        assert updated.sei_session is None


### PR DESCRIPTION
## Summary
- persist SEI session cookies on login
- reuse stored SEI session for process type and creation calls
- expire SEI session when API returns 401/403
- add Alembic migration and tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888fca3c2ec832e957089ac1da81f7f