### PR TITLE
Fix unidades select defaults

### DIFF
--- a/frontend/src/views/CriarProcesso.vue
+++ b/frontend/src/views/CriarProcesso.vue
@@ -79,8 +79,8 @@ async function carregarTipos() {
 async function carregarUnidades() {
   try {
     const { data } = await obterUnidades()
-    unidades.value = data
-    if (data.length > 0) unidade.value = data[0].id
+    unidades.value = [{ id: '', text: '' }, ...data]
+    unidade.value = ''
   } catch (err) {
     snackbarMsg.value = err.response?.data?.msg || 'Erro ao carregar unidades'
     snackbarColor.value = 'error'


### PR DESCRIPTION
## Summary
- default to blank unit on process creation screen

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688bbdc6e0f0832eabf100cfb1f35747