### PR TITLE
Fix unidades select defaults

### DIFF
--- a/frontend/src/views/CriarProcesso.vue
+++ b/frontend/src/views/CriarProcesso.vue
@@ -53,7 +53,7 @@ import { obterTipos, criarProcesso, obterUnidades } from '../services/sei'
 const tipo = ref('')
 const tipos = ref([])
 const descricao = ref('')
-const unidade = ref('')
+const unidade = ref(null)
 const unidades = ref([])
 const formRef = ref(null)
 const valid = ref(false)
@@ -80,7 +80,7 @@ async function carregarUnidades() {
   try {
     const { data } = await obterUnidades()
     unidades.value = data
-    if (data.length > 0) unidade.value = data[0].id
+    unidade.value = null
   } catch (err) {
     snackbarMsg.value = err.response?.data?.msg || 'Erro ao carregar unidades'
     snackbarColor.value = 'error'
@@ -112,7 +112,7 @@ function limpar(resetValidation = true) {
   if (resetValidation) formRef.value?.resetValidation()
   descricao.value = ''
   tipo.value = ''
-  unidade.value = ''
+  unidade.value = null
 }
 
 onMounted(() => {


### PR DESCRIPTION
## Summary
- default to blank unit on process creation screen

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688bbdc6e0f0832eabf100cfb1f35747